### PR TITLE
Fix styling on Splits component

### DIFF
--- a/src/css/Splits.scss
+++ b/src/css/Splits.scss
@@ -33,6 +33,7 @@
       .split-icon {
         max-width: 18px;
         height: 18px;
+        object-fit: contain;
         vertical-align: middle;
         filter: drop-shadow(2px 2px 1px rgba(0, 0, 0, 0.3));
       }

--- a/src/css/Splits.scss
+++ b/src/css/Splits.scss
@@ -15,13 +15,6 @@
 
     @include time;
 
-    .split-icon {
-      max-width: 18px;
-      height: 18px;
-      vertical-align: middle;
-      filter: drop-shadow(2px 2px 1px rgba(0, 0, 0, 0.3));
-    }
-
     .split-icon-empty {
       height: 18px;
       padding: 0 9px;
@@ -31,6 +24,22 @@
       display: table-cell;
       text-align: right;
       padding: 1px 6px 0px 6px;
+    }
+
+    .split-icon-container {
+      padding-right: 6px;
+      text-align: center;
+
+      .split-icon {
+        max-width: 18px;
+        height: 18px;
+        vertical-align: middle;
+        filter: drop-shadow(2px 2px 1px rgba(0, 0, 0, 0.3));
+      }
+    }
+    
+    .split-icon-container-empty {
+      padding-right: 0px;
     }
   }
 
@@ -42,13 +51,5 @@
     max-width: 0;
     white-space: nowrap;
     overflow: hidden;
-  }
-  
-  .split-icon-container {
-    padding-right: 6px !important;
-  }
-  
-  .split-icon-container-empty {
-    padding-right: 0px !important;
   }
 }

--- a/src/css/Splits.scss
+++ b/src/css/Splits.scss
@@ -3,6 +3,7 @@
 .splits {
   display: table;
   width: 100%;
+  position: relative;
 
   span.split.split-separator div {
     line-height: 18px;
@@ -15,6 +16,13 @@
 
     @include time;
 
+    .current-split-background {
+      position: absolute;
+      width: 100%;
+      height: 24px;
+      padding: 0;
+    }
+
     .split-icon-empty {
       height: 18px;
       padding: 0 9px;
@@ -24,6 +32,7 @@
       display: table-cell;
       text-align: right;
       padding: 1px 6px 0px 6px;
+      position: relative;
     }
 
     .split-icon-container {

--- a/src/layout/Split.tsx
+++ b/src/layout/Split.tsx
@@ -43,8 +43,9 @@ export default class Split extends React.Component<Props> {
             innerStyle.borderTop = `2px solid ${colorToCss(this.props.layoutState.separators_color)}`;
         }
 
+        const currentSplitBackgroundStyle: any = {};
         if (this.props.split.is_current_split) {
-            innerStyle.background = gradientToCss(this.props.splitsState.current_split_gradient);
+            currentSplitBackgroundStyle.background = gradientToCss(this.props.splitsState.current_split_gradient);
         }
 
         return (
@@ -52,6 +53,7 @@ export default class Split extends React.Component<Props> {
                 className={["split", currentSplit, separator].filter((s) => s.length > 0).join(" ")}
                 style={outerStyle}
             >
+                <div className="current-split-background" style={currentSplitBackgroundStyle}></div>
                 <div
                     key="split-icon"
                     className={splitsHaveIcons ? "split-icon-container" : "split-icon-container-empty"}

--- a/src/layout/Split.tsx
+++ b/src/layout/Split.tsx
@@ -32,11 +32,9 @@ export default class Split extends React.Component<Props> {
             innerStyle.borderBottom = this.props.splitsState.show_thin_separators
                 ? `1px solid ${colorToCss(this.props.layoutState.thin_separators_color)}`
                 : "1px solid transparent";
-            innerStyle.backgroundColor = this.props.evenOdd[1];
             outerStyle.backgroundColor = this.props.evenOdd[1];
         } else {
             innerStyle.borderBottom = "1px solid transparent";
-            innerStyle.backgroundColor = this.props.evenOdd[0];
             outerStyle.backgroundColor = this.props.evenOdd[0];
         }
         innerStyle.borderTop = innerStyle.borderBottom;

--- a/src/layout/Split.tsx
+++ b/src/layout/Split.tsx
@@ -25,14 +25,18 @@ export default class Split extends React.Component<Props> {
         const hasIcon = this.props.icon !== "";
 
         const innerStyle: any = {};
+        const outerStyle: any = {};
+
         if (this.props.split.index % 2 === 1) {
             innerStyle.borderBottom = this.props.splitsState.show_thin_separators
                 ? `1px solid ${colorToCss(this.props.layoutState.thin_separators_color)}`
                 : "1px solid transparent";
             innerStyle.backgroundColor = this.props.evenOdd[1];
+            outerStyle.backgroundColor = this.props.evenOdd[1];
         } else {
             innerStyle.borderBottom = "1px solid transparent";
             innerStyle.backgroundColor = this.props.evenOdd[0];
+            outerStyle.backgroundColor = this.props.evenOdd[0];
         }
         innerStyle.borderTop = innerStyle.borderBottom;
 
@@ -40,9 +44,8 @@ export default class Split extends React.Component<Props> {
             innerStyle.borderTop = `2px solid ${colorToCss(this.props.layoutState.separators_color)}`;
         }
 
-        const outerStyle: any = {};
         if (this.props.split.is_current_split) {
-            outerStyle.background = gradientToCss(this.props.splitsState.current_split_gradient);
+            innerStyle.background = gradientToCss(this.props.splitsState.current_split_gradient);
         }
 
         return (

--- a/src/layout/Split.tsx
+++ b/src/layout/Split.tsx
@@ -8,6 +8,7 @@ export interface Props {
     evenOdd: [Option<string>, Option<string>],
     split: LiveSplit.SplitStateJson,
     icon: string,
+    maxColumns: number,
     separatorInFrontOfSplit: boolean,
     layoutState: LiveSplit.LayoutStateJson,
 }
@@ -84,6 +85,11 @@ export default class Split extends React.Component<Props> {
                             {column.value}
                         </div>,
                     ).reverse()
+                }
+                {
+                    Array(this.props.maxColumns - this.props.split.columns.length).fill(
+                        <div style={innerStyle}></div>
+                    )
                 }
             </span>
         );

--- a/src/layout/Splits.tsx
+++ b/src/layout/Splits.tsx
@@ -39,6 +39,8 @@ export default class Splits extends React.Component<Props> {
         } else {
             style.background = gradientToCss(background.Same);
         }
+        
+        const maxColumns = Math.max.apply(Math, this.props.state.splits.map((split) => split.columns.length));
 
         return (
             <div className="splits" style={style}>
@@ -57,6 +59,7 @@ export default class Splits extends React.Component<Props> {
                             layoutState={this.props.layoutState}
                             icon={this.iconUrls[s.index]}
                             key={s.index.toString()}
+                            maxColumns={maxColumns}
                             separatorInFrontOfSplit={
                                 (this.props.state.show_final_separator &&
                                     i + 1 === this.props.state.splits.length)


### PR DESCRIPTION
- Fix #153 by switching which background we use for the inner style and the outer style.
- Fix the background not extending fully horizontally on empty splits. You can easily reproduce this issue by just setting a background color with the default splits and layout. I fixed this by passing `maxColumns` as a prop to `Split`, but it would probably be easier if `livesplit-core` did this instead.