### PR TITLE
Add support for icon and segment name in detailed timer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules
 dist
 npm-debug.log
-src/livesplit_core.js
 src/livesplit_core.wasm

--- a/src/css/DetailedTimer.scss
+++ b/src/css/DetailedTimer.scss
@@ -25,11 +25,18 @@ $comparison-font-size: 11px;
       padding: $padding 0;
       margin-right: $padding;
       box-sizing: border-box;
-      
-      img {
-        max-width: $icon-size;
+
+      .detailed-timer-icon-inner-container {
+        width: $icon-size;
         height: 100%;
-        object-fit: contain;
+        text-align: center;
+        vertical-align: center;
+
+        .detailed-timer-icon {
+          max-width: $icon-size;
+          height: 100%;
+          object-fit: contain;
+        }
       }
     }
 

--- a/src/css/DetailedTimer.scss
+++ b/src/css/DetailedTimer.scss
@@ -1,5 +1,11 @@
 @import 'Time';
 
+$icon-size: 35px;
+$padding: 6px;
+$table-padding: 2px;
+$segment-name-font-size: 15px;
+$comparison-font-size: 11px;
+
 .detailed-timer {
   position: relative;
 
@@ -7,8 +13,47 @@
 
   .detailed-timer-left-side {
     position: absolute;
-    left: 6px;
-    bottom: 2px;
-    font-size: 11px;
+    display: flex;
+    top: 0;
+    left: $padding;
+    height: 100%;
+    width: 50%;
+
+    .detailed-timer-icon-container {
+      width: $icon-size;
+      height: 100%;
+      padding: $padding 0;
+      margin-right: $padding;
+      box-sizing: border-box;
+      
+      img {
+        max-width: $icon-size;
+        height: 100%;
+        object-fit: contain;
+      }
+    }
+
+    .detailed-timer-left-side-text {
+      position: relative;
+      width: 100%;
+
+      .detailed-timer-segment-name {
+        position: absolute;
+        top: $padding;
+        left: 0;
+        width: 100%;
+        font-size: $segment-name-font-size;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        white-space: nowrap;
+      }
+  
+      .detailed-timer-comparisons {
+        position: absolute;
+        left: 0;
+        bottom: $table-padding;
+        font-size: $comparison-font-size;
+      }
+    }
   }
 }

--- a/src/layout/DetailedTimer.tsx
+++ b/src/layout/DetailedTimer.tsx
@@ -47,7 +47,9 @@ export default class DetailedTimer extends React.Component<Props> {
                     <>
                         {
                             this.icon && <div className="detailed-timer-icon-container">
-                                <img className="detailed-timer-icon" src={this.icon} />
+                                <div className="detailed-timer-icon-inner-container">
+                                    <img className="detailed-timer-icon" src={this.icon} />
+                                </div>
                             </div>
                         }
                     </>

--- a/src/layout/DetailedTimer.tsx
+++ b/src/layout/DetailedTimer.tsx
@@ -8,49 +8,62 @@ import "../css/DetailedTimer.scss";
 export interface Props { state: LiveSplit.DetailedTimerComponentStateJson }
 
 export default class DetailedTimer extends React.Component<Props> {
+    private icon: string;
+
+    constructor(props: Props) {
+        super(props);
+        this.icon = '';
+    }
+
     public render() {
-        const children = [];
-
-        children.push(renderToSVG(
-            this.props.state.timer,
-            "timer",
-        ));
-
-        children.push(renderToSVG(
-            this.props.state.segment_timer,
-            "segment-timer",
-        ));
-
-        const leftSide = [];
-
-        const table = [];
-
-        if (this.props.state.comparison1 != null) {
-            table.push(formatComparison(this.props.state.comparison1));
+        const iconChange = this.props.state.icon_change;
+        if (iconChange != null) {
+            this.icon = iconChange;
         }
 
-        if (this.props.state.comparison2 != null) {
-            table.push(formatComparison(this.props.state.comparison2));
-        }
-
-        leftSide.push(
-            <table className="detailed-timer-left-side">
-                <tbody>
-                    {table}
-                </tbody>
-            </table>,
-        );
-
-        children.push(<div>{leftSide}</div>);
+        const totalHeight = this.props.state.timer.height + this.props.state.segment_timer.height;
 
         return (
             <div
                 className="detailed-timer"
                 style={{
                     background: gradientToCss(this.props.state.background),
+                    height: totalHeight
                 }}
             >
-                {children}
+                <>{
+                    renderToSVG(
+                        this.props.state.timer,
+                        "timer",
+                    )
+                }</>
+                <>{
+                    renderToSVG(
+                        this.props.state.segment_timer,
+                        "segment-timer",
+                    )
+                }</>
+                <div className="detailed-timer-left-side">
+                    <>
+                        {
+                            this.icon && <div className="detailed-timer-icon-container">
+                                <img className="detailed-timer-icon" src={this.icon} />
+                            </div>
+                        }
+                    </>
+                    <div className="detailed-timer-left-side-text">
+                        <>{
+                            this.props.state.segment_name !== null &&
+                            <div className="detailed-timer-segment-name">{this.props.state.segment_name}</div>
+                        }</>
+                        <table className="detailed-timer-comparisons">
+                            <tbody>
+                                <>{this.props.state.comparison1 !== null && formatComparison(this.props.state.comparison1)}</>
+                                <>{this.props.state.comparison2 !== null && formatComparison(this.props.state.comparison2)}</>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
             </div>
         );
     }


### PR DESCRIPTION
I tried my best to handle different heights and widths, but it's hard with CSS.

Fixes #37 

I also noticed a difference between livesplit-core and the original LS - after the final split, LS still shows the segment name, but livesplit-core doesn't. In my opinion, we should be showing the last segment's name and icon after the run ends because we're still showing the comparisons for that segment.

LS: 
![Code_PS0KuxhnSN](https://user-images.githubusercontent.com/8262173/67616807-c1d16900-f7a2-11e9-818f-2e4c29c61e3c.png)

LSO with icon and segment name enabled:
![chrome_k0j7VHm7nU](https://user-images.githubusercontent.com/8262173/67616810-cdbd2b00-f7a2-11e9-813f-146396013092.png)