### PR TITLE
Fix split labels

### DIFF
--- a/src/css/Splits.scss
+++ b/src/css/Splits.scss
@@ -33,6 +33,7 @@
       text-align: right;
       padding: 1px 6px 0px 6px;
       position: relative;
+      white-space: nowrap;
     }
 
     .split-icon-container {

--- a/src/layout/SplitLabels.tsx
+++ b/src/layout/SplitLabels.tsx
@@ -13,8 +13,9 @@ export default class SplitLabels extends React.Component<Props> {
                     height: 22,
                 }}
             >
-                <div key="split-icon" />
-                <div key="split-name" />
+                <div className="current-split-background" />
+                <div className="split-icon-container-empty" />
+                <div className="split-name" />
                 {
                     this.props.labels.map((label, i) =>
                         <div


### PR DESCRIPTION
I think the issue was caused by a mismatching number of divs between the split labels and the regular splits.