### PR TITLE
Fix timer shadow not working in Firefox

### DIFF
--- a/src/css/Timer.scss
+++ b/src/css/Timer.scss
@@ -5,4 +5,5 @@
   padding-right: 6px;
   font-family: timer, sans-serif;
   margin-top: -10px;
+  text-shadow: none;
 }

--- a/src/layout/Timer.tsx
+++ b/src/layout/Timer.tsx
@@ -35,6 +35,7 @@ export function renderToSVG(
             style={{
                 display: "block",
                 background: gradientToCss(state.background),
+                filter: "drop-shadow(2px 2px 1px rgba(0, 0, 0, 0.5))"
             }}
         >
             <defs>


### PR DESCRIPTION
For some reason, `text-shadow` doesn't seem to work on SVGs in Firefox? Not sure what's going on, but using a `drop-shadow` filter instead of `text-shadow` seems to work in both Firefox and Chrome.

Fix #142 