### PR TITLE
Fix regression with split background positioning on Firefox and Edge

### DIFF
--- a/src/css/Splits.scss
+++ b/src/css/Splits.scss
@@ -11,7 +11,6 @@
 
   .split {
     display: table-row;
-    height: 24px;
     line-height: 20px;
 
     @include time;
@@ -19,7 +18,6 @@
     .current-split-background {
       position: absolute;
       width: 100%;
-      height: 24px;
       padding: 0;
     }
 

--- a/src/layout/Split.tsx
+++ b/src/layout/Split.tsx
@@ -11,6 +11,7 @@ export interface Props {
     maxColumns: number,
     separatorInFrontOfSplit: boolean,
     layoutState: LiveSplit.LayoutStateJson,
+    visualSplitIndex: number
 }
 
 export default class Split extends React.Component<Props> {
@@ -25,8 +26,10 @@ export default class Split extends React.Component<Props> {
         const splitsHaveIcons = this.props.splitsState.has_icons;
         const hasIcon = this.props.icon !== "";
 
+        const splitHeight = 24;
+
         const innerStyle: any = {};
-        const outerStyle: any = {};
+        const outerStyle: any = { height: splitHeight };
 
         if (this.props.split.index % 2 === 1) {
             innerStyle.borderBottom = this.props.splitsState.show_thin_separators
@@ -46,6 +49,8 @@ export default class Split extends React.Component<Props> {
         const currentSplitBackgroundStyle: any = {};
         if (this.props.split.is_current_split) {
             currentSplitBackgroundStyle.background = gradientToCss(this.props.splitsState.current_split_gradient);
+            currentSplitBackgroundStyle.top = this.props.visualSplitIndex * splitHeight;
+            currentSplitBackgroundStyle.height = splitHeight;
         }
 
         return (

--- a/src/layout/Split.tsx
+++ b/src/layout/Split.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import * as LiveSplit from "../livesplit";
 import { colorToCss, gradientToCss } from "../util/ColorUtil";
 import { Option } from "../util/OptionUtil";
+import { splitLabelHeight } from "./SplitLabels";
 
 export interface Props {
     splitsState: LiveSplit.SplitsComponentStateJson,
@@ -11,7 +12,8 @@ export interface Props {
     maxColumns: number,
     separatorInFrontOfSplit: boolean,
     layoutState: LiveSplit.LayoutStateJson,
-    visualSplitIndex: number
+    visualSplitIndex: number,
+    showingLabels: boolean
 }
 
 export default class Split extends React.Component<Props> {
@@ -49,7 +51,7 @@ export default class Split extends React.Component<Props> {
         const currentSplitBackgroundStyle: any = {};
         if (this.props.split.is_current_split) {
             currentSplitBackgroundStyle.background = gradientToCss(this.props.splitsState.current_split_gradient);
-            currentSplitBackgroundStyle.top = this.props.visualSplitIndex * splitHeight;
+            currentSplitBackgroundStyle.top = this.props.visualSplitIndex * splitHeight + (this.props.showingLabels ? splitLabelHeight : 0);
             currentSplitBackgroundStyle.height = splitHeight;
         }
 

--- a/src/layout/SplitLabels.tsx
+++ b/src/layout/SplitLabels.tsx
@@ -4,13 +4,15 @@ export interface Props {
     labels: string[],
 }
 
+export const splitLabelHeight = 22;
+
 export default class SplitLabels extends React.Component<Props> {
     public render() {
         return (
             <span
                 className="split"
                 style={{
-                    height: 22,
+                    height: splitLabelHeight,
                 }}
             >
                 <div className="current-split-background" />

--- a/src/layout/Splits.tsx
+++ b/src/layout/Splits.tsx
@@ -66,6 +66,7 @@ export default class Splits extends React.Component<Props> {
                                 || (i === 0 && this.props.state.column_labels != null)
                             }
                             visualSplitIndex={i}
+                            showingLabels={this.props.state.column_labels != null}
                         />,
                     )
                 }

--- a/src/layout/Splits.tsx
+++ b/src/layout/Splits.tsx
@@ -65,6 +65,7 @@ export default class Splits extends React.Component<Props> {
                                     i + 1 === this.props.state.splits.length)
                                 || (i === 0 && this.props.state.column_labels != null)
                             }
+                            visualSplitIndex={i}
                         />,
                     )
                 }


### PR DESCRIPTION
Fix #186 

We were previously relying on `position: absolute` defaulting to being relative to the table row, but that assumption doesn't hold true on most browsers. I tested this in Chrome, Firefox, and Edge.