### PR TITLE
Remove Mention of Electron from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 LiveSplit One is a version of LiveSplit that uses the multiplatform
 [livesplit-core](https://github.com/LiveSplit/livesplit-core) Library and Web
-Technologies like React and Electron to create a new LiveSplit experience that
+Technologies like React to create a new LiveSplit experience that
 works on a lot of different platforms.
 
 The Web Version is available [here](https://one.livesplit.org/).


### PR DESCRIPTION
At this point in time, we barely support using Electron for a desktop app so there is very little sense in having this here. If we ever get support for making a fully working electron build this can be easily added back.