### PR TITLE
Show variable values as leaderboard columns

### DIFF
--- a/src/css/LiveSplit.scss
+++ b/src/css/LiveSplit.scss
@@ -14,8 +14,8 @@
 
   .view-container {
     position: relative;
-    width: calc(100% - 40px);
-    height: calc(100% - 40px);
+    min-width: calc(100% - 40px);
+    min-height: calc(100% - 40px);
     margin: $view-margin;
 
     .buttons {

--- a/src/css/Markdown.scss
+++ b/src/css/Markdown.scss
@@ -15,9 +15,13 @@
   .inline-div {
     display: inline;
   }
-  
-  .markdown img {
-    vertical-align: middle;
+
+  .markdown {
+    line-height: 1.2em;
+
+    img {
+      vertical-align: middle;
+    }
   }
   
   code {

--- a/src/css/RunEditor.scss
+++ b/src/css/RunEditor.scss
@@ -42,21 +42,24 @@
   }
 
   .run-editor-additional-info {
-    width: 650px;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
-    border: 1px solid $border-color;
-    border-collapse: collapse;
-    margin-left: 5px;
     background-color: $light-row-color;
-  }
 
-  .run-editor-rules {
-    padding-left: 10px;
-    padding-right: 10px;
+    .run-editor-rules {
+      padding-left: 10px;
+      padding-right: 10px;
+      border: 1px solid $border-color;
+      border-collapse: collapse;
+    }
   }
 
   .run-editor-tab {
     margin-left: 5px;
+    width: 650px;
+
+    .settings-table {
+      width: 100%;
+    }
   }
 
   .run-editor-info {
@@ -107,6 +110,16 @@
 
   .leaderboard-row:hover {
     background: $hover-row-color !important;
+  }
+
+  .leaderboard-time-column,
+  .variable-column {
+    width: 120px;
+  }
+
+  .variable-column,
+  .splits-download-column {
+    text-align: center;
   }
 
   .timing-selection > button {

--- a/src/css/RunEditor.scss
+++ b/src/css/RunEditor.scss
@@ -4,6 +4,8 @@
 @import "Toggle";
 @import 'variables';
 
+$tab-width: 600px;
+
 .run-editor {
   @include context-menu;
   @include markdown;
@@ -44,6 +46,7 @@
   .run-editor-additional-info {
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
     background-color: $light-row-color;
+    width: $tab-width;
 
     .run-editor-rules {
       padding-left: 10px;
@@ -55,10 +58,29 @@
 
   .run-editor-tab {
     margin-left: 5px;
-    width: 650px;
+    min-width: $tab-width;
 
     .settings-table {
       width: 100%;
+    }
+  }
+
+  .video-outer-container {
+    width: 100%;
+    padding-top: calc(100% * 9 / 16);
+    margin-top: 5px;
+    position: relative;
+
+    .video-inner-container {
+      width: 100%;
+      height: 100%;
+      position: absolute;
+      top: 0;
+
+      iframe {
+        width: 100%;
+        height: 100%
+      }
     }
   }
 
@@ -112,14 +134,23 @@
     background: $hover-row-color !important;
   }
 
+  .leaderboard-rank-column,
+  .splits-download-column {
+    width: 36px;
+  }
+
   .leaderboard-time-column,
   .variable-column {
-    width: 120px;
+    width: 100px;
   }
 
   .variable-column,
   .splits-download-column {
     text-align: center;
+  }
+
+  .leaderboard-expanded-row > td {
+    max-width: 0;
   }
 
   .timing-selection > button {

--- a/src/ui/Embed.tsx
+++ b/src/ui/Embed.tsx
@@ -39,39 +39,26 @@ function tryTwitchFromUri(uri: string): Option<JSX.Element> {
     return null;
 }
 
-function resolveYoutube(videoId: string): JSX.Element {
+function videoIframe(videoSource: string): JSX.Element {
     return (
-        <div style={{ paddingTop: 5 }}>
-            <iframe
-                id="ytplayer"
-                itemType="text/html"
-                src={`https://www.youtube.com/embed/${videoId}?wmode=transparent`
-                }
-                allowFullScreen
-                frameBorder="0"
-                style={{
-                    width: "100%",
-                    height: 240,
-                }}
-            />
+        <div className="video-outer-container">
+            <div className="video-inner-container">
+                <iframe
+                    id="ytplayer"
+                    itemType="text/html"
+                    src={videoSource}
+                    allowFullScreen
+                    frameBorder="0"
+                />
+            </div>
         </div>
     );
 }
 
+function resolveYoutube(videoId: string): JSX.Element {
+    return videoIframe(`https://www.youtube.com/embed/${videoId}?wmode=transparent`);
+}
+
 function resolveTwitch(videoId: string): JSX.Element {
-    return (
-        <div style={{ paddingTop: 5 }}>
-            <iframe
-                id="ytplayer"
-                itemType="text/html"
-                src={`https://player.twitch.tv/?video=${videoId}&autoplay=false`}
-                allowFullScreen
-                frameBorder="0"
-                style={{
-                    width: "100%",
-                    height: 240,
-                }}
-            />
-        </div>
-    );
+    return videoIframe(`https://player.twitch.tv/?video=${videoId}&autoplay=false`);
 }

--- a/src/ui/RunEditor.tsx
+++ b/src/ui/RunEditor.tsx
@@ -795,7 +795,7 @@ export class RunEditor extends React.Component<Props, State> {
     }
 
     private renderLeaderboard(category: Option<Category>): JSX.Element {
-        const leaderboard = getLeaderboard(this.state.editor.game, this.state.editor.category);
+        const leaderboard = this.getCurrentLeaderboard(category);
         if (leaderboard === undefined) {
             return <div />;
         }
@@ -1312,6 +1312,14 @@ export class RunEditor extends React.Component<Props, State> {
         );
     }
 
+    private getCurrentLeaderboard(category: Option<Category>) {
+        const categoryName = category?.name;
+        if (categoryName) {
+            return getLeaderboard(this.state.editor.game, categoryName);
+        }
+        return undefined;
+    }
+
     private getCurrentCategoriesInfo() {
         let categoryNames = ["Any%", "Low%", "100%"];
         let category = null;
@@ -1745,7 +1753,8 @@ export class RunEditor extends React.Component<Props, State> {
 
         if (tab === Tab.Leaderboard) {
             const { category } = this.getCurrentCategoriesInfo();
-            if (category !== null) {
+            const leaderboard = this.getCurrentLeaderboard(category);
+            if (leaderboard !== undefined) {
                 return true;
             }
         }

--- a/src/ui/RunEditor.tsx
+++ b/src/ui/RunEditor.tsx
@@ -912,7 +912,7 @@ export class RunEditor extends React.Component<Props, State> {
                             const renderedComment = renderMarkdown(comment);
 
                             expandedRow =
-                                <tr key={`${run.id}_expanded`} className={evenOdd}>
+                                <tr key={`${run.id}_expanded`} className={`leaderboard-expanded-row ${evenOdd}`}>
                                     <td colSpan={4 + (variableColumns?.length ?? 0)}>
                                         {embed}
                                         <div className="markdown" style={{
@@ -969,7 +969,7 @@ export class RunEditor extends React.Component<Props, State> {
                                     cursor: "pointer",
                                 }}
                             >
-                                <td className="number">{isUnique ? rank : "—"}</td>
+                                <td className="leaderboard-rank-column number">{isUnique ? rank : "—"}</td>
                                 <td>
                                     {
                                         run.players.data.map((p, i) => {

--- a/src/ui/RunEditor.tsx
+++ b/src/ui/RunEditor.tsx
@@ -9,7 +9,7 @@ import {
     downloadLeaderboard, getLeaderboard, downloadPlatformList, getPlatforms,
     downloadRegionList, getRegions, downloadGameInfo, getGameInfo, downloadGameInfoByGameId, downloadCategoriesByGameId,
 } from "../api/GameList";
-import { Category, Run, getRun } from "../api/SpeedrunCom";
+import { Category, Run, Variable, getRun } from "../api/SpeedrunCom";
 import { Option, expect, map, assert } from "../util/OptionUtil";
 import { downloadById } from "../util/SplitsIO";
 import { formatLeaderboardTime } from "../util/TimeUtil";
@@ -489,10 +489,7 @@ export class RunEditor extends React.Component<Props, State> {
 
         const variables = expect(gameInfo.variables, "We need the variables to be embedded");
         for (const variable of variables.data) {
-            if (
-                (variable.category == null || (variable.category === map(category, (c) => c.id)))
-                && (variable.scope.type === "full-game" || variable.scope.type === "global")
-            ) {
+            if (this.variableIsValidForCategory(variable, category)) {
                 if (variable["is-subcategory"]) {
                     let currentFilterValue = this.filters.variables.get(variable.name);
                     if (currentFilterValue === undefined) {
@@ -616,6 +613,11 @@ export class RunEditor extends React.Component<Props, State> {
         );
     }
 
+    private variableIsValidForCategory(variable: Variable, category: Option<Category>) {
+        return (variable.category == null || variable.category === map(category, (c) => c.id)) &&
+            (variable.scope.type === "full-game" || variable.scope.type === "global");
+    }
+
     private updateFilters() {
         this.resetIndividualLeaderboardState();
         this.update();
@@ -653,10 +655,7 @@ export class RunEditor extends React.Component<Props, State> {
             }
             const variables = expect(gameInfo.variables, "We need the variables to be embedded");
             for (const variable of variables.data) {
-                if (
-                    (variable.category == null || (variable.category === map(category, (c) => c.id)))
-                    && (variable.scope.type === "full-game" || variable.scope.type === "global")
-                ) {
+                if (this.variableIsValidForCategory(variable, category)) {
                     speedrunComVariables.push({
                         text: variable.name,
                         value: {
@@ -826,13 +825,19 @@ export class RunEditor extends React.Component<Props, State> {
 
         const uniquenessSet = new Set();
 
+        const allVariables = gameInfo?.variables;
+        const variables = allVariables
+            ? allVariables.data.filter((variable) => this.variableIsValidForCategory(variable, category))
+            : null;
+
         return (
-            <table className="table run-editor-tab" style={{ width: 450 }}>
+            <table className="table run-editor-tab">
                 <thead className="table-header">
                     <tr>
                         <th>Rank</th>
                         <th>Player</th>
                         <th>Time</th>
+                        {variables && variables.map((variable) => <th>{variable.name}</th>)}
                         <th>Splits</th>
                     </tr>
                 </thead>
@@ -852,19 +857,20 @@ export class RunEditor extends React.Component<Props, State> {
                             return null;
                         }
 
-                        const renderedVariables = [];
+                        const renderedVariableColumns = [];
+                        const renderedVariablesInExpandedRow = [];
 
-                        const variables = gameInfo?.variables;
-                        if (variables !== undefined) {
-                            for (const [keyId, valueId] of Object.entries(run.values)) {
-                                const variable = variables.data.find((v) => v.id === keyId);
-                                if (variable !== undefined) {
+                        if (variables !== null) {
+                            for (const variable of variables) {
+                                const valueId = run.values[variable.id];
+                                let valueName;
+                                if (valueId) {
                                     const value = Object.entries(variable.values.values).find(
                                         ([listValueId]) => listValueId === valueId,
                                     );
-                                    const valueName = map(value, (v) => v[1].label);
+                                    valueName = map(value, (v) => v[1].label);
                                     if (valueName !== undefined) {
-                                        renderedVariables.push(
+                                        renderedVariablesInExpandedRow.push(
                                             <tr>
                                                 <td>{variable.name}:</td>
                                                 <td>{valueName}</td>
@@ -872,13 +878,13 @@ export class RunEditor extends React.Component<Props, State> {
                                         );
                                     }
                                 }
+                                renderedVariableColumns.push(
+                                    <td className="variable-column">{valueName || ""}</td>
+                                );
                             }
 
-                            for (const variable of variables.data) {
-                                if (
-                                    (variable.category == null || (variable.category === category?.id))
-                                    && (variable.scope.type === "full-game" || variable.scope.type === "global")
-                                ) {
+                            for (const variable of variables) {
+                                if (this.variableIsValidForCategory(variable, category)) {
                                     const variableValueId = run.values[variable.id];
                                     const variableValue = map(variableValueId, (i) => variable.values.values[i]);
                                     const filterValue = this.filters.variables.get(variable.name);
@@ -915,7 +921,7 @@ export class RunEditor extends React.Component<Props, State> {
 
                             expandedRow =
                                 <tr key={`${run.id}_expanded`} className={evenOdd}>
-                                    <td colSpan={4}>
+                                    <td colSpan={4 + (variables?.length || 0)}>
                                         {embed}
                                         <div className="markdown" style={{
                                             minHeight: 5,
@@ -946,7 +952,7 @@ export class RunEditor extends React.Component<Props, State> {
                                                             <td>{p}{run.system.emulated ? " Emulator" : null}</td>
                                                         </tr>,
                                                 )}
-                                                {renderedVariables}
+                                                {renderedVariablesInExpandedRow}
                                             </tbody>
                                         </table>
                                     </td>
@@ -1006,7 +1012,7 @@ export class RunEditor extends React.Component<Props, State> {
                                         })
                                     }
                                 </td>
-                                <td style={{ width: 120 }} className="number">
+                                <td className="leaderboard-time-column number">
                                     <a
                                         href={run.weblink}
                                         target="_blank"
@@ -1016,7 +1022,8 @@ export class RunEditor extends React.Component<Props, State> {
                                         {formatLeaderboardTime(run.times.primary_t, hideMilliseconds)}
                                     </a>
                                 </td>
-                                <td style={{ textAlign: "center" }}>
+                                {renderedVariableColumns}
+                                <td className="splits-download-column">
                                     {
                                         map(run.splits, (s) => <i
                                             onClick={(e) => {
@@ -1067,11 +1074,7 @@ export class RunEditor extends React.Component<Props, State> {
             }
             const variables = expect(gameInfo.variables, "We need the variables to be embedded");
             for (const variable of variables.data) {
-                if (
-                    (variable.category == null || (variable.category === category?.id))
-                    && (variable.scope.type === "full-game" || variable.scope.type === "global")
-                    && variable["is-subcategory"]
-                ) {
+                if (this.variableIsValidForCategory(variable, category) && variable["is-subcategory"]) {
                     const currentValue = this.state.editor.metadata.speedrun_com_variables[variable.name];
                     const foundValue = Object.values(variable.values.values).find((v) => v.label === currentValue);
                     if (foundValue !== undefined && foundValue.rules !== undefined) {
@@ -1082,7 +1085,7 @@ export class RunEditor extends React.Component<Props, State> {
         }
 
         return (
-            <div className="run-editor-additional-info">
+            <div className="run-editor-tab run-editor-additional-info">
                 <div className="run-editor-rules markdown">{gameRules}{rules}{subcategoryRules}</div>
             </div>
         );


### PR DESCRIPTION
Fix #94 

I also made all the run editor tabs be the same width and cleaned up some of the Run Editor logic.

As mentioned on the issue, we maybe want to also show some of the other details as well (date and platform), or potentially jusr show none of this stuff. I'm OK with either route - if we don't want to show variables, then I'll just keep the cleanup stuff in this PR.