### PR TITLE
Update Splits and KeyValue components to use flexbox instead of tables

### DIFF
--- a/src/css/KeyValue.scss
+++ b/src/css/KeyValue.scss
@@ -5,6 +5,7 @@
   height: $default-component-height;
   line-height: $default-component-line-height;
   padding: 0px 6px;
+  display: flex;
 
   @include time;
 
@@ -13,26 +14,48 @@
     line-height: $two-row-line-height;
     padding-top: $two-row-extra-padding;
     padding-bottom: $two-row-extra-padding;
+    flex-wrap: wrap;
+    align-items: stretch;
+
+    .key-value-value {
+      width: 100%;
+    }
   }
 
-  &.key-value-center .key-value-key {
-    text-align: center;
-  }
+  &.key-value-center {
+    justify-content: center;
 
-  table {
-    width: 100%;
+    .key-value-key {
+      justify-content: center;
+    }
   }
 
   .key-value-key {
-    width: 100%;
-    max-width: 0;
-    text-overflow: ellipsis;
+    display: flex;
+    flex-grow: 1;
+    padding-top: 1px;
+    justify-content: flex-start;
+    align-items: center;
     overflow: hidden;
-    white-space: nowrap;
+
+    .key-value-key-inner {
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
   }
   
   .key-value-value {
-    text-align: right;
-    white-space: nowrap;
+    display: flex;
+    flex-shrink: 0;
+    justify-content: flex-end;
+    align-items: center;
+    overflow: hidden;
+
+    .key-value-value-inner {
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
   }
 }

--- a/src/css/Splits.scss
+++ b/src/css/Splits.scss
@@ -1,7 +1,11 @@
-@import 'Time';
+@import "Time";
+
+$split-column-width: 60px;
+$split-label-height: 22px;
+$split-height: 24px;
+$split-icon-size: 18px;
 
 .splits {
-  display: table;
   width: 100%;
   position: relative;
 
@@ -10,14 +14,22 @@
   }
 
   .split {
-    display: table-row;
     line-height: 20px;
+    display: flex;
+    position: relative;
+    width: 100%;
+    height: $split-height;
 
     @include time;
+
+    &.split-label {
+      height: $split-label-height;
+    }
 
     .current-split-background {
       position: absolute;
       width: 100%;
+      height: 100%;
       padding: 0;
     }
 
@@ -26,39 +38,68 @@
       padding: 0 9px;
     }
 
+    .split-name {
+      display: flex;
+      align-items: center;
+      justify-content: flex-start;
+      overflow: hidden;
+      flex-grow: 1;
+      padding-left: 0px;
+      padding-top: 1px;
+
+      .split-name-inner {
+        padding: 0;
+        max-width: 100%;
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+      }
+    }
+
+    .split-time {
+      display: flex;
+      align-items: center;
+      justify-content: flex-end;
+      padding-left: 0;
+
+      &.split-time-full {
+        width: $split-column-width;
+        flex-shrink: 0;
+      }
+
+      &.split-label {
+        padding-top: 1px;
+      }
+
+      .split-time-inner {
+        padding: 0;
+      }
+    }
+
     div {
-      display: table-cell;
-      text-align: right;
-      padding: 1px 6px 0px 6px;
+      padding: 0px 6px;
       position: relative;
       white-space: nowrap;
     }
 
     .split-icon-container {
       padding-right: 6px;
-      text-align: center;
+      width: $split-icon-size;
+      display: flex;
+      flex-shrink: 0;
+      align-items: center;
+      justify-content: center;
 
       .split-icon {
-        max-width: 18px;
-        height: 18px;
+        max-width: $split-icon-size;
+        height: $split-icon-size;
         object-fit: contain;
-        vertical-align: middle;
         filter: drop-shadow(2px 2px 1px rgba(0, 0, 0, 0.3));
       }
     }
-    
+
     .split-icon-container-empty {
       padding-right: 0px;
     }
-  }
-
-  .split-name {
-    text-overflow: ellipsis;
-    width: 100%;
-    padding-left: 0px !important;
-    text-align: left !important;
-    max-width: 0;
-    white-space: nowrap;
-    overflow: hidden;
   }
 }

--- a/src/layout/KeyValueGeneric.tsx
+++ b/src/layout/KeyValueGeneric.tsx
@@ -23,45 +23,40 @@ export interface Props {
 
 export default class KeyValueGeneric extends React.Component<Props> {
     public render() {
-        const keyCell = <td
+        const keyCell = <div
             className="key-value-key"
             style={{
                 color: map(this.props.keyColor, colorToCss),
             }}
         >
-            {this.props.keyText}
-        </td>;
+            <div className="key-value-key-inner">{this.props.keyText}</div>
+        </div>;
 
-        const valueCell = <td
+        const valueCell = <div
             className="key-value-value time"
             style={{
                 color: map(this.props.valueColor, colorToCss),
             }}
         >
-            {this.props.valueText}
-        </td>;
+            <div className="key-value-value-inner">{this.props.valueText}</div>
+        </div>;
 
         let keyValueRows: JSX.Element;
         let wrapperClassName: string;
         if (this.props.display === KeyValueDisplay.Center) {
-            keyValueRows = <tr>{keyCell}</tr>;
+            keyValueRows = keyCell;
             wrapperClassName = "key-value-center";
-        } else if (this.props.display === KeyValueDisplay.SplitTwoRows) {
-            keyValueRows = <>
-                <tr>
-                    {keyCell}
-                </tr>
-                <tr>
-                    {valueCell}
-                </tr>
-            </>;
-            wrapperClassName = "key-value-two-rows";
         } else {
-            keyValueRows = <tr>
+            keyValueRows = <>
                 {keyCell}
                 {valueCell}
-            </tr>;
-            wrapperClassName = "";
+            </>;
+
+            if (this.props.display === KeyValueDisplay.SplitTwoRows) {
+                wrapperClassName = "key-value-two-rows";
+            } else {
+                wrapperClassName = "";
+            }
         }
 
         return (
@@ -71,11 +66,7 @@ export default class KeyValueGeneric extends React.Component<Props> {
                     background: gradientToCss(this.props.wrapperBackground),
                 }}
             >
-                <table>
-                    <tbody>
-                        {keyValueRows}
-                    </tbody>
-                </table>
+                {keyValueRows}
             </div>
         );
     }

--- a/src/layout/Split.tsx
+++ b/src/layout/Split.tsx
@@ -2,18 +2,15 @@ import * as React from "react";
 import * as LiveSplit from "../livesplit-core";
 import { colorToCss, gradientToCss } from "../util/ColorUtil";
 import { Option } from "../util/OptionUtil";
-import { splitLabelHeight } from "./SplitLabels";
 
 export interface Props {
     splitsState: LiveSplit.SplitsComponentStateJson,
     evenOdd: [Option<string>, Option<string>],
     split: LiveSplit.SplitStateJson,
     icon: string,
-    maxColumns: number,
     separatorInFrontOfSplit: boolean,
     layoutState: LiveSplit.LayoutStateJson,
     visualSplitIndex: number,
-    showingLabels: boolean
 }
 
 export default class Split extends React.Component<Props> {
@@ -28,10 +25,8 @@ export default class Split extends React.Component<Props> {
         const splitsHaveIcons = this.props.splitsState.has_icons;
         const hasIcon = this.props.icon !== "";
 
-        const splitHeight = 24;
-
         const innerStyle: any = {};
-        const outerStyle: any = { height: splitHeight };
+        const outerStyle: any = {};
 
         if (this.props.split.index % 2 === 1) {
             innerStyle.borderBottom = this.props.splitsState.show_thin_separators
@@ -51,10 +46,17 @@ export default class Split extends React.Component<Props> {
         const currentSplitBackgroundStyle: any = {};
         if (this.props.split.is_current_split) {
             currentSplitBackgroundStyle.background = gradientToCss(this.props.splitsState.current_split_gradient);
-            currentSplitBackgroundStyle.top = this.props.visualSplitIndex * splitHeight +
-                (this.props.showingLabels ? splitLabelHeight : 0);
-            currentSplitBackgroundStyle.height = splitHeight;
         }
+
+        let lastEmptyColumnIndex = this.props.split.columns.length;
+        for (let i = this.props.split.columns.length - 1; i >= 0; i--) {
+            const column = this.props.split.columns[i];
+            if (!column.value) {
+                lastEmptyColumnIndex = i;
+            }
+        }
+
+        const columns = this.props.split.columns.slice(0, lastEmptyColumnIndex);
 
         return (
             <span
@@ -78,26 +80,25 @@ export default class Split extends React.Component<Props> {
                     className="split-name"
                     style={innerStyle}
                 >
-                    {this.props.split.name}
+                    <div className="split-name-inner">
+                        {this.props.split.name}
+                    </div>
                 </div>
                 {
-                    this.props.split.columns.map((column, i) =>
+                    columns.map((column, i) =>
                         <div
                             key={i}
-                            className="split-time time"
+                            className={`split-time time ${i < columns.length - 1 ? "split-time-full" : ""}`}
                             style={{
                                 ...innerStyle,
                                 color: colorToCss(column.visual_color),
                             }}
                         >
-                            {column.value}
+                            <div className="split-time-inner">
+                                {column.value}
+                            </div>
                         </div>,
                     ).reverse()
-                }
-                {
-                    Array(this.props.maxColumns - this.props.split.columns.length).fill(
-                        <div style={innerStyle}></div>,
-                    )
                 }
             </span>
         );

--- a/src/layout/SplitLabels.tsx
+++ b/src/layout/SplitLabels.tsx
@@ -4,16 +4,11 @@ export interface Props {
     labels: string[],
 }
 
-export const splitLabelHeight = 22;
-
 export default class SplitLabels extends React.Component<Props> {
     public render() {
         return (
             <span
-                className="split"
-                style={{
-                    height: splitLabelHeight,
-                }}
+                className="split split-label"
             >
                 <div className="current-split-background" />
                 <div className="split-icon-container-empty" />
@@ -22,7 +17,7 @@ export default class SplitLabels extends React.Component<Props> {
                     this.props.labels.map((label, i) =>
                         <div
                             key={i}
-                            className="split-time"
+                            className={`split-time split-label ${i < this.props.labels.length - 1 ? "split-time-full" : ""}`}
                         >
                             {label}
                         </div>,

--- a/src/layout/Splits.tsx
+++ b/src/layout/Splits.tsx
@@ -40,8 +40,6 @@ export default class Splits extends React.Component<Props> {
             style.background = gradientToCss(background.Same);
         }
 
-        const maxColumns = Math.max.apply(Math, this.props.state.splits.map((split) => split.columns.length));
-
         return (
             <div className="splits" style={style}>
                 {
@@ -59,14 +57,12 @@ export default class Splits extends React.Component<Props> {
                             layoutState={this.props.layoutState}
                             icon={this.iconUrls[s.index]}
                             key={s.index.toString()}
-                            maxColumns={maxColumns}
                             separatorInFrontOfSplit={
                                 (this.props.state.show_final_separator &&
                                     i + 1 === this.props.state.splits.length)
                                 || (i === 0 && this.props.state.column_labels !== null)
                             }
                             visualSplitIndex={i}
-                            showingLabels={this.props.state.column_labels !== null}
                         />,
                     )
                 }

--- a/src/ui/LiveSplit.tsx
+++ b/src/ui/LiveSplit.tsx
@@ -174,7 +174,7 @@ export class LiveSplit extends React.Component<{}, State> {
                     importLayout={this.importLayoutFromFile.bind(this)}
                     importSplits={this.importSplitsFromFile.bind(this)}
                 >
-                    <div style={{ width: "fit-content" }}>
+                    <div>
                         <div
                             onClick={(_) => this.splitOrStart()}
                             style={{
@@ -190,7 +190,7 @@ export class LiveSplit extends React.Component<{}, State> {
                                 onResize={(width) => this.onResize(width)}
                             />
                         </div>
-                        <div className="buttons">
+                        <div className="buttons" style={{ width: this.state.layoutWidth }}>
                             <div className="small">
                                 <button onClick={(_) => this.undoSplit()}>
                                     <i className="fa fa-arrow-up" aria-hidden="true" /></button>


### PR DESCRIPTION
Fix #241 

We'll still need to do another refactor to get two row mode to work for the Splits, but it should be significantly easier to get to that point from here.