### PR TITLE
Implement Support for Abbreviations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8505,6 +8505,11 @@
         }
       }
     },
+    "resize-observer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resize-observer/-/resize-observer-1.0.0.tgz",
+      "integrity": "sha512-D7UFShDm2TgrEDEyeg+/tTEbvOgPWlvPAfJtxiKp+qutu6HowmcGJKjECgGru0PPDIj3SAucn3ZPpOx54fF7DQ=="
+    },
     "resolve": {
       "version": "1.14.2",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.2.tgz",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "react-resizable": "^1.10.1",
     "react-sidebar": "^3.0.2",
     "react-toastify": "^5.5.0",
-    "react-twemoji": "0.2.3"
+    "react-twemoji": "0.2.3",
+    "resize-observer": "^1.0.0"
   },
   "devDependencies": {
     "@types/node": "^13.1.7",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "serve": "webpack-dev-server",
     "start": "webpack-dev-server --open",
     "start:electron": "webpack --electron && electron dist/index.html",
-    "test": "mocha --exit --timeout 60000 test/**/*.js || true"
+    "test": "mocha --exit test/**/*.js || true"
   },
   "author": "",
   "license": "ISC",

--- a/src/css/Abbreviated.scss
+++ b/src/css/Abbreviated.scss
@@ -1,0 +1,6 @@
+.abbreviated {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    width: 100%;
+}

--- a/src/css/KeyValue.scss
+++ b/src/css/KeyValue.scss
@@ -23,9 +23,16 @@
 
   &.key-value-center {
     justify-content: center;
+    text-align: center;
 
     .key-value-key {
       justify-content: center;
+    }
+  }
+
+  &.key-value-left-right {
+    .key-value-key {
+      padding-right: $side-padding;
     }
   }
 
@@ -36,14 +43,8 @@
     justify-content: flex-start;
     align-items: center;
     overflow: hidden;
-
-    .key-value-key-inner {
-      overflow: hidden;
-      white-space: nowrap;
-      text-overflow: ellipsis;
-    }
   }
-  
+
   .key-value-value {
     display: flex;
     flex-shrink: 0;

--- a/src/css/Title.scss
+++ b/src/css/Title.scss
@@ -40,7 +40,7 @@ $game-icon-size: $two-row-height - $vertical-padding * 2;
       height: 50%;
       padding: 0 $side-padding;
 
-      &.centered div {
+      &.centered .abbreviated {
         text-align: center;
       }
     }
@@ -66,7 +66,7 @@ $game-icon-size: $two-row-height - $vertical-padding * 2;
         overflow: hidden;
         padding: 0 $side-padding;
 
-        &.centered div {
+        &.centered .abbreviated {
           text-align: center;
         }
       }

--- a/src/css/Title.scss
+++ b/src/css/Title.scss
@@ -40,8 +40,8 @@ $game-icon-size: $two-row-height - $vertical-padding * 2;
       height: 50%;
       padding: 0 $side-padding;
 
-      &.centered {
-        justify-content: center;
+      &.centered div {
+        text-align: center;
       }
     }
 
@@ -66,8 +66,8 @@ $game-icon-size: $two-row-height - $vertical-padding * 2;
         overflow: hidden;
         padding: 0 $side-padding;
 
-        &.centered {
-          justify-content: center;
+        &.centered div {
+          text-align: center;
         }
       }
 

--- a/src/layout/Abbreviated.tsx
+++ b/src/layout/Abbreviated.tsx
@@ -1,0 +1,73 @@
+import * as React from "react";
+import { expect } from "../util/OptionUtil";
+import { ResizeObserver } from "resize-observer";
+
+import "../css/Abbreviated.scss";
+
+export interface Props {
+    abbreviations: string[],
+}
+
+export default class Abbreviated extends React.Component<Props> {
+    public sorted: string[];
+    public oldAbbreviations: string[];
+    public element: React.RefObject<HTMLDivElement>;
+
+    constructor(props: Props) {
+        super(props);
+        this.element = React.createRef();
+        this.sorted = [...this.props.abbreviations];
+        this.sorted.sort((a, b) => b.length - a.length);
+        this.oldAbbreviations = this.props.abbreviations;
+    }
+
+    public componentDidMount() {
+        const element = expect(this.element.current, "Element should exist by now.");
+        new ResizeObserver(() => {
+            this.chooseAbbreviation();
+        }).observe(element);
+        this.chooseAbbreviation();
+    }
+
+    public componentDidUpdate() {
+        const arrEq = (a: string[], b: string[]) => {
+            if (a.length !== b.length) {
+                return false;
+            }
+            for (let i = 0; i < a.length; i++) {
+                if (a[i] !== b[i]) {
+                    return false;
+                }
+            }
+            return true;
+        };
+        if (!arrEq(this.props.abbreviations, this.oldAbbreviations)) {
+            this.oldAbbreviations = this.props.abbreviations;
+            this.sorted = [...this.props.abbreviations];
+            this.sorted.sort((a, b) => b.length - a.length);
+            this.chooseAbbreviation();
+        }
+    }
+
+    public render() {
+        return <div
+            className="abbreviated"
+            ref={this.element}
+        />;
+    }
+
+    private chooseAbbreviation() {
+        if (this.element.current === null) {
+            // We can still get here for a short time when unmounting.
+            return;
+        }
+
+        for (const abbrev of this.sorted) {
+            this.element.current.innerText = abbrev;
+            if (this.element.current.scrollWidth <= this.element.current.clientWidth) {
+                return;
+            }
+        }
+        this.element.current.innerText = this.sorted[0];
+    }
+}

--- a/src/layout/Abbreviated.tsx
+++ b/src/layout/Abbreviated.tsx
@@ -1,8 +1,10 @@
 import * as React from "react";
 import { expect } from "../util/OptionUtil";
-import { ResizeObserver } from "resize-observer";
+import { install } from "resize-observer";
 
 import "../css/Abbreviated.scss";
+
+if (!(window as any).ResizeObserver) { install(); }
 
 export interface Props {
     abbreviations: string[],
@@ -23,9 +25,10 @@ export default class Abbreviated extends React.Component<Props> {
 
     public componentDidMount() {
         const element = expect(this.element.current, "Element should exist by now.");
-        new ResizeObserver(() => {
+        new (window as any).ResizeObserver(() => {
             this.chooseAbbreviation();
         }).observe(element);
+
         this.chooseAbbreviation();
     }
 

--- a/src/layout/KeyValue.tsx
+++ b/src/layout/KeyValue.tsx
@@ -14,6 +14,7 @@ export default class KeyValue extends React.Component<Props> {
                 KeyValueDisplay.SplitOneRow
             }
             keyText={this.props.state.key}
+            keyAbbreviations={this.props.state.key_abbreviations}
             keyColor={this.props.state.key_color}
             valueText={this.props.state.value}
             valueColor={this.props.state.value_color}

--- a/src/layout/KeyValueGeneric.tsx
+++ b/src/layout/KeyValueGeneric.tsx
@@ -5,6 +5,7 @@ import { colorToCss, gradientToCss } from "../util/ColorUtil";
 import { map } from "../util/OptionUtil";
 
 import "../css/KeyValue.scss";
+import Abbreviated from "./Abbreviated";
 
 export enum KeyValueDisplay {
     Center,
@@ -16,6 +17,7 @@ export interface Props {
     display: KeyValueDisplay,
     keyColor: LiveSplit.Color | null,
     keyText: string,
+    keyAbbreviations: string[],
     valueColor: LiveSplit.Color | null,
     valueText: string | null,
     wrapperBackground: LiveSplit.Gradient,
@@ -29,7 +31,7 @@ export default class KeyValueGeneric extends React.Component<Props> {
                 color: map(this.props.keyColor, colorToCss),
             }}
         >
-            <div className="key-value-key-inner">{this.props.keyText}</div>
+            <Abbreviated abbreviations={[...this.props.keyAbbreviations, this.props.keyText]} />
         </div>;
 
         const valueCell = <div
@@ -55,7 +57,7 @@ export default class KeyValueGeneric extends React.Component<Props> {
             if (this.props.display === KeyValueDisplay.SplitTwoRows) {
                 wrapperClassName = "key-value-two-rows";
             } else {
-                wrapperClassName = "";
+                wrapperClassName = "key-value-left-right";
             }
         }
 

--- a/src/layout/Layout.tsx
+++ b/src/layout/Layout.tsx
@@ -31,7 +31,7 @@ export default class Layout extends React.Component<Props> {
                     <ResizableBox
                         className="resizable-layout"
                         width={this.props.width}
-                        minConstraints={[200, 0]}
+                        minConstraints={[160, 0]}
                         height={0}
                         handle={<span onClick={(event: React.SyntheticEvent) => { event.stopPropagation(); }} className="resizable-handle" />}
                         onResize={

--- a/src/layout/Text.tsx
+++ b/src/layout/Text.tsx
@@ -19,6 +19,7 @@ export default class Text extends React.Component<Props> {
                 display={KeyValueDisplay.Center}
                 keyColor={this.props.state.left_center_color}
                 keyText={text.Center}
+                keyAbbreviations={[]}
                 valueColor={null}
                 valueText={null}
                 wrapperBackground={this.props.state.background}
@@ -32,6 +33,7 @@ export default class Text extends React.Component<Props> {
             }
             keyColor={this.props.state.left_center_color}
             keyText={text.Split[0]}
+            keyAbbreviations={[]}
             valueColor={this.props.state.right_color}
             valueText={text.Split[1]}
             wrapperBackground={this.props.state.background}

--- a/src/layout/Title.tsx
+++ b/src/layout/Title.tsx
@@ -4,6 +4,7 @@ import { colorToCss, gradientToCss } from "../util/ColorUtil";
 import { map } from "../util/OptionUtil";
 
 import "../css/Title.scss";
+import Abbreviated from "./Abbreviated";
 
 export interface Props { state: LiveSplit.TitleComponentStateJson }
 
@@ -21,7 +22,8 @@ export default class Title extends React.Component<Props> {
 
         const finishedRunsExist = this.props.state.finished_runs !== null;
         const attemptsExist = this.props.state.attempts !== null;
-        const twoLines = this.props.state.line2 !== null;
+        const line2 = this.props.state.line2;
+        const twoLines = line2 !== null;
         const showIcon = iconUrl !== "";
         const showAttempts = attemptsExist || finishedRunsExist;
 
@@ -58,7 +60,7 @@ export default class Title extends React.Component<Props> {
                 >
                     {
                         twoLines && <span className={`title-game ${alignmentClass}`}>
-                            <div className="title-text">{this.props.state.line1}</div>
+                            <Abbreviated abbreviations={this.props.state.line1} />
                         </span>
                     }
                     <div className={`lower-row ${numLinesClass} ${alignmentClass}`}>
@@ -69,9 +71,9 @@ export default class Title extends React.Component<Props> {
                             </div>
                         }
                         <div className={`title-category ${alignmentClass}`}>
-                            <div className="title-text">
-                                {twoLines ? this.props.state.line2 : this.props.state.line1}
-                            </div>
+                            <Abbreviated abbreviations={
+                                line2 !== null ? line2 : this.props.state.line1
+                            } />
                         </div>
                         {
                             showAttempts &&

--- a/src/ui/LiveSplit.tsx
+++ b/src/ui/LiveSplit.tsx
@@ -598,8 +598,6 @@ export class LiveSplit extends React.Component<{}, State> {
 
     private getDefaultRun() {
         const run = Run.new();
-        run.setGameName("Game");
-        run.setCategoryName("Category");
         run.pushSegment(Segment.new("Time"));
         return run;
     }

--- a/test/rendering-test.js
+++ b/test/rendering-test.js
@@ -22,6 +22,17 @@ describe("Layout Rendering Tests", function() {
     const SCREENSHOTS_FOLDER = "test/screenshots";
     const SPLITS_FOLDER = "test/splits";
 
+    const startServer = async () => {
+        return new Promise((resolve) => {
+            serverProcess = fork("./node_modules/webpack-dev-server/bin/webpack-dev-server.js", [], { silent: true });
+            serverProcess.stdout.on("data", (data) => {
+                if (data.toString().includes("Compiled successfully.")) {
+                    resolve();
+                }
+            });
+        });
+    };
+
     const findElement = async (selector) => {
         return driver.wait(until.elementLocated(selector));
     };
@@ -37,7 +48,7 @@ describe("Layout Rendering Tests", function() {
     }
 
     before(async () => {
-        serverProcess = fork("./node_modules/webpack-dev-server/bin/webpack-dev-server.js");
+        await startServer();
 
         const service = new chrome.ServiceBuilder(chromedriver.path).build();
         chrome.setDefaultService(service);

--- a/test/rendering-test.js
+++ b/test/rendering-test.js
@@ -13,7 +13,9 @@ const hex64 = require("hex64");
 const pixelmatch = require("pixelmatch");
 const PNG = require("pngjs").PNG;
 
-describe("Layout Rendering Tests", () => {
+describe("Layout Rendering Tests", function() {
+    this.timeout(40000);
+
     let driver, serverProcess;
 
     const LAYOUTS_FOLDER = "test/layouts";
@@ -62,7 +64,9 @@ describe("Layout Rendering Tests", () => {
     });
 
     const testRendering = (layoutName, splitsName, expectedHash) => {
-        it(`Renders the ${layoutName} layout with the ${splitsName} splits correctly`, async () => {
+        it(`Renders the ${layoutName} layout with the ${splitsName} splits correctly`, async function() {
+            this.timeout(5000);
+
             await clickElement(By.xpath(".//button[contains(text(), 'Layout')]"));
             await clickElement(By.xpath(".//button[contains(text(), 'Import')]"));
             await loadFile(`${LAYOUTS_FOLDER}/${layoutName}.ls1l`);


### PR DESCRIPTION
This implements abbreviations. For the longest time we thought it's not possible to implement them in the web, but it turns out that it can work.

This implements support for the key value pair components so far. Abbreviations are still missing for the Title component. This will need some additional support from livesplit-core.