### PR TITLE
Create an About dialog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6813,6 +6813,12 @@
         }
       }
     },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
+      "dev": true
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -6941,6 +6947,12 @@
           "dev": true
         }
       }
+    },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+      "dev": true
     },
     "node-forge": {
       "version": "0.9.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
     "html-webpack-plugin": "^3.2.0",
     "imghash": "0.0.6",
     "mocha": "^7.0.1",
+    "moment": "^2.24.0",
+    "node-fetch": "^2.6.0",
     "pixelmatch": "^5.1.0",
     "pngjs": "^3.4.0",
     "sass": "^1.24.4",

--- a/src/css/About.scss
+++ b/src/css/About.scss
@@ -1,0 +1,69 @@
+@import 'mobile';
+@import 'variables';
+
+$text-width: 400px;
+$icon-size: 40px;
+$title-font-size: 40px;
+$build-version-font-size: 11px;
+$link-color: #56b0ff;
+
+.about {
+  .about-inner-container {
+    background-color: $light-row-color;
+    padding: $ui-large-margin;
+    border: 1px solid $border-color;
+    width: fit-content;
+  
+    .livesplit-title {
+      display: flex;
+      align-items: center;
+  
+      .livesplit-icon {
+        height: $icon-size;
+        margin-right: $ui-margin;
+  
+        img {
+          height: 100%;
+        }
+      }
+  
+      .title-text {
+        font-weight: bold;
+        font-size: $title-font-size;
+      }
+    }
+  
+    .build-version {
+      font-size: $build-version-font-size;
+    }
+  
+    .contributors-header {
+      margin-bottom: 0;
+    }
+  
+    .contributor {
+      margin-block-start: 0.5em;
+      margin-block-end: 0.5em;
+  
+      &:last-child {
+        margin-block-end: 0;
+      }
+    }
+  
+    a {
+      color: $link-color;
+    }
+  
+    p {
+      max-width: $text-width;
+
+      @include mobile {
+        max-width: 100%;
+      }
+    }
+
+    @include mobile {
+      box-sizing: border-box;
+    }
+  }
+}

--- a/src/type-definitions/webpack-globals.d.ts
+++ b/src/type-definitions/webpack-globals.d.ts
@@ -1,0 +1,3 @@
+declare const BUILD_DATE: string;
+declare const COMMIT_HASH: string;
+declare const CONTRIBUTORS_LIST: string[];

--- a/src/ui/About.tsx
+++ b/src/ui/About.tsx
@@ -1,0 +1,42 @@
+import * as React from "react";
+
+import LiveSplitIcon from "../assets/icon_small.png";
+
+import "../css/About.scss";
+
+export class About extends React.Component {
+    public render() {
+        return (
+            <div className="about">
+                <div className="about-inner-container">
+                    <div className="livesplit-title">
+                        <span className="livesplit-icon">
+                            <img src={LiveSplitIcon} alt="LiveSplit Logo" />
+                        </span>
+                        <div className="title-text">LiveSplit One</div>
+                    </div>
+                    <p className="build-version">
+                        <a href={`https://github.com/LiveSplit/LiveSplitOne/commit/${COMMIT_HASH}`} target="_blank">
+                            Version: {COMMIT_HASH} ({BUILD_DATE})
+                        </a>
+                    </p>
+                    <p>LiveSplit One is a multiplatform version of LiveSplit, the sleek,
+                    highly-customizable timer for speedrunners.</p>
+                    <p>
+                        <a href="https://github.com/LiveSplit/LiveSplitOne" target="_blank">
+                            View Source Code on GitHub
+                        </a>
+                    </p>
+                    <h1 className="contributors-header">Contributors</h1>
+                    {
+                        CONTRIBUTORS_LIST.map((contributor) => (
+                            <p className="contributor">
+                                <a href={`https://github.com/${contributor}`} target="_blank">{contributor}</a>
+                            </p>
+                        ))
+                    }
+                </div>
+            </div>
+        );
+    }
+}

--- a/src/ui/SideBarContent.tsx
+++ b/src/ui/SideBarContent.tsx
@@ -9,9 +9,10 @@ import LiveSplitIcon from "../assets/icon_small.png";
 import "../css/SideBarContent.scss";
 
 export interface SidebarCallbacks {
-    openTimerView(): void,
+    openTimerView(remount: boolean): void,
     openSplitsView(): void,
     openLayoutView(): void,
+    openAboutView(): void,
     closeRunEditor(save: boolean): void,
     closeLayoutEditor(save: boolean): void,
     openRunEditor(): void,
@@ -88,7 +89,7 @@ export class SideBarContent extends React.Component<Props, State> {
                             <i className="fa fa-sync" aria-hidden="true" /> Default
                         </button>
                         <hr />
-                        <button onClick={(_) => this.props.callbacks.openTimerView()}>
+                        <button onClick={(_) => this.props.callbacks.openTimerView(false)}>
                             <i className="fa fa-caret-left" aria-hidden="true" /> Back
                         </button>
                     </div>
@@ -139,7 +140,7 @@ export class SideBarContent extends React.Component<Props, State> {
                             <i className="fa fa-sync" aria-hidden="true" /> Default
                         </button>
                         <hr />
-                        <button onClick={(_) => this.props.callbacks.openTimerView()}>
+                        <button onClick={(_) => this.props.callbacks.openTimerView(false)}>
                             <i className="fa fa-caret-left" aria-hidden="true" /> Back
                         </button>
                     </div>
@@ -188,6 +189,18 @@ export class SideBarContent extends React.Component<Props, State> {
                                 <i className="fa fa-times" aria-hidden="true" /> Cancel
                             </button>
                         </div>
+                    </div>
+                );
+                break;
+            }
+            case MenuKind.About: {
+                sidebarContent = (
+                    <div className="sidebar-buttons">
+                        <h2>About</h2>
+                        <hr />
+                        <button onClick={(_) => this.props.callbacks.openTimerView(true)}>
+                            <i className="fa fa-caret-left" aria-hidden="true" /> Back
+                        </button>
                     </div>
                 );
                 break;
@@ -275,6 +288,10 @@ export class SideBarContent extends React.Component<Props, State> {
                         </button>
                         <button onClick={() => this.props.callbacks.openSettingsEditor()}>
                             <i className="fa fa-cog" aria-hidden="true" /> Settings
+                        </button>
+                        <hr />
+                        <button onClick={(_) => this.props.callbacks.openAboutView()}>
+                            <i className="fa fa-info-circle" aria-hidden="true" /> About
                         </button>
                     </div >
                 );


### PR DESCRIPTION
In terms of branding, I think we should stick to "LiveSplit One" everywhere rather than doing something like "LiveSplit One Web" or "LiveSplit One Desktop" (although we should still use these internally to name our repos). This kind of goes along with the whole "One" theme - LiveSplit One is a single application that works on a lot of different platforms, and the different contexts (web, desktop) are just different ways to use it.

Fix #28 