### PR TITLE
Implement Gamepad Support

### DIFF
--- a/src/ui/HotkeyButton.tsx
+++ b/src/ui/HotkeyButton.tsx
@@ -41,21 +41,22 @@ export class HotkeyButton extends React.Component<Props, State> {
 
                             let gamepadIdx = 0;
                             for (const gamepad of gamepads) {
-                                if (gamepad === null) { continue; }
+                                if (gamepadIdx >= oldButtonState.length) {
+                                    oldButtonState[gamepadIdx] = [];
+                                }
 
-                                let buttonIdx = 0;
-                                for (const button of gamepad.buttons) {
-                                    const oldState = oldButtonState[gamepadIdx]?.[buttonIdx] ?? false;
-                                    if (button.pressed && !oldState) {
-                                        this.props.setValue(`Gamepad${buttonIdx}`);
+                                if (gamepad !== null) {
+                                    let buttonIdx = 0;
+                                    for (const button of gamepad.buttons) {
+                                        const oldState = oldButtonState[gamepadIdx]?.[buttonIdx] ?? false;
+                                        if (button.pressed && !oldState) {
+                                            this.props.setValue(`Gamepad${buttonIdx}`);
+                                        }
+
+                                        oldButtonState[gamepadIdx][buttonIdx] = button.pressed;
+
+                                        buttonIdx++;
                                     }
-
-                                    if (oldButtonState[gamepadIdx] === undefined) {
-                                        oldButtonState[gamepadIdx] = [];
-                                    }
-                                    oldButtonState[gamepadIdx][buttonIdx] = button.pressed;
-
-                                    buttonIdx++;
                                 }
 
                                 gamepadIdx++;


### PR DESCRIPTION
This implements gamepad support for the hotkeys. This allows controlling LiveSplit One without having to focus the browser tab. There seem to be some unfortunate limitations though. Chrome for example acquires exclusive access to the gamepads (at least on Windows with DirectInput). Firefox however doesn't, so you likely would want to use Firefox if Chrome is causing problems with your controller.

The PR in livesplit-core needs to be merged first: https://github.com/LiveSplit/livesplit-core/pull/310