### PR TITLE
Fix linter running in CI without building livesplit-core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,12 @@ jobs:
         set -e
         npm run build:core
 
+    - name: Set up tslint matcher
+      run: echo "::add-matcher::.github/workflows/tslint.json"
+
+    - name: Run tslint
+      run: npm run lint
+
     - name: Build Frontend
       run: |
         set -e
@@ -124,24 +130,3 @@ jobs:
         PUBLISH_DIR: ./dist
       with:
         forceOrphan: true
-
-  linter:
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout commit
-      uses: actions/checkout@v1
-
-    - name: Install Node
-      uses: actions/setup-node@v1
-      with:
-        node-version: '12.x' # FIXME: https://github.com/actions/setup-node/issues/26
-
-    - name: Install dependencies
-      run: npm install
-
-    - name: Set up tslint matcher
-      run: echo "::add-matcher::.github/workflows/tslint.json"
-
-    - name: Run tslint
-      run: npm run lint

--- a/tslint.json
+++ b/tslint.json
@@ -36,9 +36,11 @@
         ],
         "no-var-keyword": true,
         "prefer-object-spread": true,
-        "strict-type-predicates": true,
         "ordered-imports": false,
-        "variable-name": ["check-format", "allow-leading-underscores"]
+        "variable-name": [
+            "check-format",
+            "allow-leading-underscores"
+        ]
     },
     "rulesDirectory": []
 }


### PR DESCRIPTION
We committed a linter error to master that wasn't caught by the CI because we were previously running `npm run lint` without building livesplit-core. This made the command innacurate to a proper development environment.

Moving the linter to the normal build ensures that the full setup can happen before we run the linter. This also reduces the amount of setup repetition in the `ci.yml` file. One downside (maybe) is that the linter becomes a blocker for deployment.

[Here's a build that catches the linter error.](https://github.com/LiveSplit/LiveSplitOne/runs/510162370)

@CryZe Let me know your thoughts on what approach we should take for this.