### PR TITLE
Implement a Splits Selection View

### DIFF
--- a/src/api/GameList.ts
+++ b/src/api/GameList.ts
@@ -20,7 +20,7 @@ const gameIdToCategoriesPromises: Map<string, Promise<Category[]>> = new Map();
 const gameIdToGameInfoMap: Map<string, Game> = new Map();
 const gameIdToGameInfoPromises: Map<string, Promise<Game>> = new Map();
 const gameAndCategoryToLeaderboardPromises: Map<string, Promise<void>> = new Map();
-const gameAndCategoryToLeaderboardMap: Map<string, Run<PlayersEmbedded>[]> = new Map();
+const gameAndCategoryToLeaderboardMap: Map<string, Array<Run<PlayersEmbedded>>> = new Map();
 let gameListPromise: Option<Promise<void>> = null;
 let platformListPromise: Option<Promise<void>> = null;
 let regionListPromise: Option<Promise<void>> = null;
@@ -61,7 +61,7 @@ export function getRegions(): Map<string, string> {
     return regionList;
 }
 
-export function getLeaderboard(gameName: string, categoryName: string): Run<PlayersEmbedded>[] | undefined {
+export function getLeaderboard(gameName: string, categoryName: string): Array<Run<PlayersEmbedded>> | undefined {
     const key = JSON.stringify({ gameName, categoryName });
     return gameAndCategoryToLeaderboardMap.get(key);
 }

--- a/src/api/SpeedrunCom.ts
+++ b/src/api/SpeedrunCom.ts
@@ -148,10 +148,10 @@ export interface Record {
     run: Run,
 }
 
-export type PlayersNotEmbedded = (PlayerUserRef | PlayerGuest)[];
+export type PlayersNotEmbedded = Array<PlayerUserRef | PlayerGuest>;
 
 export interface PlayersEmbedded {
-    data: (PlayerUser | PlayerGuest)[],
+    data: Array<PlayerUser | PlayerGuest>,
 }
 
 export interface Run<PlayerEmbedding = PlayersNotEmbedded> {
@@ -314,7 +314,7 @@ async function executePaginatedRequest<T>(uri: string): Promise<Page<T>> {
     return new Page(data as T[], next);
 }
 
-export async function getGame(gameId: string, embeds?: "variables"[]): Promise<Game> {
+export async function getGame(gameId: string, embeds?: Array<"variables">): Promise<Game> {
     const parameters = [];
     if (embeds !== undefined) {
         parameters.push(`embed=${embeds.join(",")}`);
@@ -349,7 +349,7 @@ export async function getCategories(gameId: string): Promise<Category[]> {
 export async function getLeaderboard(
     gameId: string,
     categoryId: string,
-    embeds?: "players"[],
+    embeds?: Array<"players">,
 ): Promise<Leaderboard> {
     const parameters = [];
     if (embeds !== undefined) {

--- a/src/css/LayoutEditor.scss
+++ b/src/css/LayoutEditor.scss
@@ -25,7 +25,6 @@
 
       button {
         width: 40px;
-        height: 40px;
         font-size: 15px;
         display: block;
       }

--- a/src/css/LiveSplit.scss
+++ b/src/css/LiveSplit.scss
@@ -36,7 +36,6 @@ $sidebar-button-height: 42px;
 
       .small {
         button {
-          height: 40px;
           width: calc(50% - #{$ui-margin / 2})
         }
 

--- a/src/css/Sidebar.scss
+++ b/src/css/Sidebar.scss
@@ -17,7 +17,6 @@ $header-font-size: 24px;
 
   > div > div.small > button {
     width: 50%;
-    height: 40px;
     font-size: 18px;
   }
 
@@ -44,7 +43,6 @@ $header-font-size: 24px;
 
     > button {
       width: 100%;
-      height: 40px;
     }
 
     .livesplit-title {
@@ -66,7 +64,6 @@ $header-font-size: 24px;
   .choose-comparison {
     > button {
       width: 30px;
-      height: 40px;
       font-size: 28px;
     }
 

--- a/src/css/SplitsSelection.scss
+++ b/src/css/SplitsSelection.scss
@@ -1,6 +1,7 @@
 @import 'mobile';
 @import 'variables';
 @import 'Table';
+@import 'ContextMenu';
 
 $loading-text-font-size: 40px;
 $splits-row-width: 500px;
@@ -68,7 +69,7 @@ $splits-row-height: 40px;
             overflow: hidden;
             white-space: nowrap;
             text-overflow: ellipsis;
-            
+
             &.splits-game {
               margin-bottom: $ui-margin;
             }
@@ -82,6 +83,8 @@ $splits-row-height: 40px;
         .splits-row-buttons {
           flex-shrink: 0;
           margin-left: $ui-large-margin;
+
+          @include context-menu;
 
           button {
             background: transparent;

--- a/src/css/SplitsSelection.scss
+++ b/src/css/SplitsSelection.scss
@@ -1,0 +1,89 @@
+@import 'variables';
+
+$loading-text-font-size: 40px;
+$header-text-size: 30px;
+$splits-title-text-size: 20px;
+
+$splits-row-min-width: 800px;
+$splits-row-height: 70px;
+
+.splits-selection {
+  .loading {
+    display: flex;
+    width: fit-content;
+    font-size: $loading-text-font-size;
+
+    .loading-text {
+      margin-left: $ui-margin;
+    }
+  }
+
+  .splits-selection-container {
+    display: flex;
+    flex-wrap: nowrap;
+    flex-direction: column;
+
+    .main-actions {
+      display: flex;
+      justify-content: flex-start;
+    
+      button {
+        margin-bottom: $ui-large-margin / 2;
+        margin-right: $ui-margin;
+      }
+    }
+  
+    .splits-table {
+      background-color: $dark-row-color;
+      border: 1px solid $border-color;
+      margin: $ui-large-margin/2 0;
+      width: fit-content;
+  
+      .header-text {
+        font-size: $header-text-size;
+        padding: $ui-margin;
+        font-weight: bold;
+        background-color: $header-row-color;
+      }
+
+      .splits-row {
+        display: flex;
+        flex-wrap: nowrap;
+        align-items: center;
+        padding: $ui-margin;
+        height: $splits-row-height;
+        min-width: $splits-row-min-width;
+
+        &:nth-of-type(odd) {
+          background-color: $light-row-color;
+        }
+
+        &:first-child {
+          border-top: 1px solid $border-color;
+        }
+
+        .splits-title-text {
+          font-size: $splits-title-text-size;
+          flex-grow: 1;
+
+          .splits-game {
+            margin-bottom: $ui-margin;
+          }
+        }
+
+        .splits-row-buttons {
+          flex-shrink: 0;
+          margin-left: $ui-large-margin;
+
+          button {
+            margin: 0;
+
+            &:not(:last-child) {
+              margin-right: $ui-margin;
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/css/SplitsSelection.scss
+++ b/src/css/SplitsSelection.scss
@@ -1,9 +1,10 @@
+@import 'mobile';
 @import 'variables';
 @import 'Table';
 
 $loading-text-font-size: 40px;
-$splits-title-width: 400px;
-$splits-buttons-width: 225px;
+$splits-row-width: 500px;
+$splits-row-height: 40px;
 
 .splits-selection {
   .loading {
@@ -26,26 +27,51 @@ $splits-buttons-width: 225px;
       justify-content: flex-start;
 
       button {
+        margin-top: 0;
         margin-bottom: $ui-large-margin / 2;
         margin-right: $ui-margin;
       }
+
+      @include mobile {
+        margin-top: $ui-margin;
+        margin-left: $ui-margin;
+      }
     }
 
-    @include table;
-
     .splits-table {
-      margin-top: $ui-large-margin / 2;
+      background-color: $dark-row-color;
+      border: 1px solid $border-color;
+      margin: $ui-large-margin/2 0;
       width: fit-content;
 
       .splits-row {
+        display: flex;
+        flex-wrap: nowrap;
+        align-items: center;
+        padding: $ui-margin;
+        height: $splits-row-height;
+        width: $splits-row-width;
+
+        &:nth-of-type(odd) {
+          background-color: $light-row-color;
+        }
+
+        &.selected {
+          background: $selected-row-color;
+        }
+
         .splits-title-text {
-          width: $splits-title-width;
+          flex-grow: 1;
           overflow: hidden;
 
           .splits-text {
             overflow: hidden;
             white-space: nowrap;
             text-overflow: ellipsis;
+            
+            &.splits-game {
+              margin-bottom: $ui-margin;
+            }
           }
         }
 
@@ -54,9 +80,8 @@ $splits-buttons-width: 225px;
         }
 
         .splits-row-buttons {
-          display: flex;
-          justify-content: flex-end;
-          width: $splits-buttons-width;
+          flex-shrink: 0;
+          margin-left: $ui-large-margin;
 
           button {
             background: transparent;
@@ -75,6 +100,17 @@ $splits-buttons-width: 225px;
             }
           }
         }
+
+        @include mobile {
+          width: 100%;
+          box-sizing: border-box;
+          height: $splits-row-height + 2 * $ui-margin;
+        }
+      }
+
+      @include mobile {
+        width: 100%;
+        box-sizing: border-box;
       }
     }
   }

--- a/src/css/SplitsSelection.scss
+++ b/src/css/SplitsSelection.scss
@@ -1,5 +1,7 @@
 @import 'variables';
+@import 'Table';
 
+// TODO: Clean this up again.
 $loading-text-font-size: 40px;
 $header-text-size: 30px;
 $splits-title-text-size: 20px;
@@ -26,57 +28,65 @@ $splits-row-height: 70px;
     .main-actions {
       display: flex;
       justify-content: flex-start;
-    
+
       button {
         margin-bottom: $ui-large-margin / 2;
         margin-right: $ui-margin;
       }
     }
-  
+
+    @include table;
+
     .splits-table {
-      background-color: $dark-row-color;
-      border: 1px solid $border-color;
-      margin: $ui-large-margin/2 0;
+
+    //   background-color: $dark-row-color;
+    //   border: 1px solid $border-color;
+      margin-top: $ui-large-margin / 2;
       width: fit-content;
-  
-      .header-text {
-        font-size: $header-text-size;
-        padding: $ui-margin;
-        font-weight: bold;
-        background-color: $header-row-color;
-      }
 
       .splits-row {
-        display: flex;
-        flex-wrap: nowrap;
-        align-items: center;
-        padding: $ui-margin;
-        height: $splits-row-height;
-        min-width: $splits-row-min-width;
+      //     display: flex;
+      //     flex-wrap: nowrap;
+      //     align-items: center;
+      //     padding: $ui-margin;
+      //     height: $splits-row-height;
+      //     min-width: $splits-row-min-width;
 
-        &:nth-of-type(odd) {
-          background-color: $light-row-color;
-        }
+      //     &:nth-of-type(odd) {
+      //       background-color: $light-row-color;
+      //     }
 
-        &:first-child {
-          border-top: 1px solid $border-color;
-        }
+      //     .splits-title-text {
+      //       font-size: $splits-title-text-size;
+      //       flex-grow: 1;
 
-        .splits-title-text {
-          font-size: $splits-title-text-size;
-          flex-grow: 1;
+      //       .splits-game {
+      //         margin-bottom: $ui-margin;
+      //       }
+      //     }
 
-          .splits-game {
-            margin-bottom: $ui-margin;
-          }
+        &.selected .splits-row-buttons button {
+            opacity: 70%;
         }
 
         .splits-row-buttons {
-          flex-shrink: 0;
-          margin-left: $ui-large-margin;
+          display: flex;
+          justify-content: flex-end;
+          // align-items: flex-end;
+          // flex-shrink: 0;
+          // margin-left: $ui-large-margin;
 
           button {
+            background: transparent;
+            border: 0;
+            opacity: 50%;
             margin: 0;
+            transition: 0.3s;
+            color: white;
+
+            &:hover {
+              opacity: 100%;
+            }
 
             &:not(:last-child) {
               margin-right: $ui-margin;

--- a/src/css/SplitsSelection.scss
+++ b/src/css/SplitsSelection.scss
@@ -1,13 +1,9 @@
 @import 'variables';
 @import 'Table';
 
-// TODO: Clean this up again.
 $loading-text-font-size: 40px;
-$header-text-size: 30px;
-$splits-title-text-size: 20px;
-
-$splits-row-min-width: 800px;
-$splits-row-height: 70px;
+$splits-title-width: 400px;
+$splits-buttons-width: 225px;
 
 .splits-selection {
   .loading {
@@ -38,43 +34,29 @@ $splits-row-height: 70px;
     @include table;
 
     .splits-table {
-
-    //   background-color: $dark-row-color;
-    //   border: 1px solid $border-color;
       margin-top: $ui-large-margin / 2;
       width: fit-content;
 
       .splits-row {
-      //     display: flex;
-      //     flex-wrap: nowrap;
-      //     align-items: center;
-      //     padding: $ui-margin;
-      //     height: $splits-row-height;
-      //     min-width: $splits-row-min-width;
+        .splits-title-text {
+          width: $splits-title-width;
+          overflow: hidden;
 
-      //     &:nth-of-type(odd) {
-      //       background-color: $light-row-color;
-      //     }
-
-      //     .splits-title-text {
-      //       font-size: $splits-title-text-size;
-      //       flex-grow: 1;
-
-      //       .splits-game {
-      //         margin-bottom: $ui-margin;
-      //       }
-      //     }
+          .splits-text {
+            overflow: hidden;
+            white-space: nowrap;
+            text-overflow: ellipsis;
+          }
+        }
 
         &.selected .splits-row-buttons button {
-            opacity: 70%;
+          opacity: 70%;
         }
 
         .splits-row-buttons {
           display: flex;
           justify-content: flex-end;
-          // align-items: flex-end;
-          // flex-shrink: 0;
-          // margin-left: $ui-large-margin;
+          width: $splits-buttons-width;
 
           button {
             background: transparent;

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -75,6 +75,8 @@ button {
   border-radius: 5px;
   font-weight: bold;
   font-family: "fira", sans-serif;
+  // TODO: Buttons tend to be 40px high. Remove that in all the other places.
+  height: 40px;
 }
 
 a {

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -75,7 +75,6 @@ button {
   border-radius: 5px;
   font-weight: bold;
   font-family: "fira", sans-serif;
-  // TODO: Buttons tend to be 40px high. Remove that in all the other places.
   height: 40px;
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -18,6 +18,7 @@ async function run() {
 
     const {
         splits,
+        splitsKey,
         layout,
         hotkeys,
         layoutWidth,
@@ -30,6 +31,7 @@ async function run() {
                     splits={splits}
                     layout={layout}
                     hotkeys={hotkeys}
+                    splitsKey={splitsKey}
                     layoutWidth={layoutWidth}
                 />
                 <ToastContainer

--- a/src/storage/index.tsx
+++ b/src/storage/index.tsx
@@ -33,7 +33,6 @@ function getSplitsInfo(run: RunRef): SplitsInfo {
 }
 
 function parseSplitsAndGetInfo(splits: Uint8Array): Option<SplitsInfo> {
-    // TODO: We leak the ParseRunResult if it's unsuccessful everywhere else. whoops
     return Run.parseArray(splits, "", false).with((r) => {
         if (r.parsedSuccessfully()) {
             return r.unwrap();
@@ -52,7 +51,6 @@ async function getDb(): Promise<IDBPDatabase<unknown>> {
                 const splitsInfoStore = db.createObjectStore("splitsInfo", {
                     autoIncrement: true,
                 });
-                splitsInfoStore.createIndex("game", "game");
 
                 if (oldVersion === 1) {
                     const settingsStore = tx.objectStore("settings");

--- a/src/ui/DragUpload.tsx
+++ b/src/ui/DragUpload.tsx
@@ -4,81 +4,85 @@ import { toast } from "react-toastify";
 import "../css/DragUpload.scss";
 
 export interface Props {
-  children: any,
-  importLayout(file: File): Promise<void>,
-  importSplits(file: File): Promise<void>,
+    children: any,
+    importLayout?: (file: File) => Promise<void>,
+    importSplits(file: File): Promise<void>,
 }
 
 export default class DragUpload extends React.Component<Props> {
-  public componentDidMount() {
-    const dropZone = document.getElementById("upload-drop-zone");
-    const dropZoneOverlay = document.getElementById("upload-drop-zone-overlay");
-    const importLayout = this.props.importLayout;
-    const importSplits = this.props.importSplits;
+    public componentDidMount() {
+        const dropZone = document.getElementById("upload-drop-zone");
+        const dropZoneOverlay = document.getElementById("upload-drop-zone-overlay");
+        const importLayout = this.props.importLayout;
+        const importSplits = this.props.importSplits;
 
-    if (dropZone === null) {
-      return;
+        if (dropZone === null) {
+            return;
+        }
+
+        dropZone.addEventListener("dragenter", (event) => {
+            event.preventDefault();
+            event.stopPropagation();
+
+            if (dropZoneOverlay) {
+                dropZoneOverlay.style.visibility = "visible";
+            }
+        });
+
+        dropZone.addEventListener("dragleave", (event) => {
+            if (dropZoneOverlay &&
+                (event.pageX < 10 ||
+                    event.pageY < 10 ||
+                    window.innerWidth - event.pageX < 10 ||
+                    window.innerHeight - event.pageY < 10)
+            ) {
+                dropZoneOverlay.style.visibility = "hidden";
+            }
+        });
+
+        dropZone.addEventListener("dragover", (event) => {
+            event.preventDefault();
+            event.stopPropagation();
+        });
+
+        dropZone.addEventListener("drop", (event) => {
+            event.preventDefault();
+            event.stopPropagation();
+
+            if (dropZoneOverlay) {
+                dropZoneOverlay.style.visibility = "hidden";
+            }
+
+            const dataTransfer = event.dataTransfer;
+            if (dataTransfer) {
+                const files = dataTransfer.files;
+                const file = files[0];
+                if (file) {
+                    return importSplits(file).catch(() => {
+                        if (importLayout !== undefined) {
+                            return importLayout(file).catch(() => {
+                                toast.error("The file could not be parsed.");
+                            });
+                        }
+                        toast.error("The file could not be parsed.");
+                        return null;
+                    });
+                }
+            }
+            return null;
+        });
     }
 
-    dropZone.addEventListener("dragenter", (event) => {
-      event.preventDefault();
-      event.stopPropagation();
-
-      if (dropZoneOverlay) {
-        dropZoneOverlay.style.visibility = "visible";
-      }
-    });
-
-    dropZone.addEventListener("dragleave", (event) => {
-      if (dropZoneOverlay &&
-        (event.pageX < 10 ||
-          event.pageY < 10 ||
-          window.innerWidth - event.pageX < 10 ||
-          window.innerHeight - event.pageY < 10)
-      ) {
-        dropZoneOverlay.style.visibility = "hidden";
-      }
-    });
-
-    dropZone.addEventListener("dragover", (event) => {
-      event.preventDefault();
-      event.stopPropagation();
-    });
-
-    dropZone.addEventListener("drop", (event) => {
-      event.preventDefault();
-      event.stopPropagation();
-
-      if (dropZoneOverlay) {
-        dropZoneOverlay.style.visibility = "hidden";
-      }
-
-      const dataTransfer = event.dataTransfer;
-      if (dataTransfer) {
-        const files = dataTransfer.files;
-        const file = files[0];
-        if (file) {
-          return importSplits(file).catch(() => {
-            return importLayout(file).catch(() => {
-              toast.error("The file could not be parsed.");
-            });
-          });
-        }
-      }
-      return null;
-    });
-  }
-
-  public render() {
-    return (
-      <div id="upload-drop-zone">
-        <div id="upload-drop-zone-overlay">
-          <div className="overlay-text">
-            Waiting for drop...
+    public render() {
+        return (
+            <div id="upload-drop-zone">
+                <div id="upload-drop-zone-overlay">
+                    <div className="overlay-text">
+                        Waiting for drop...
           </div>
-        </div>
-        {this.props.children}
-      </div>
-    );
-  }
+                </div>
+                {this.props.children}
+            </div>
+        );
+    }
 }

--- a/src/ui/LiveSplit.tsx
+++ b/src/ui/LiveSplit.tsx
@@ -20,6 +20,7 @@ import * as Storage from "../storage";
 
 import "react-toastify/dist/ReactToastify.css";
 import "../css/LiveSplit.scss";
+import { SplitsSelection } from "./SplitsSelection";
 
 import LiveSplitIcon from "../assets/icon_small.png";
 
@@ -230,6 +231,8 @@ export class LiveSplit extends React.Component<Props, State> {
             />;
         } else if (this.state.menu.kind === MenuKind.About) {
             return <About callbacks={this} />;
+        } else if (this.state.menu.kind === MenuKind.Splits) {
+            return <SplitsSelection callbacks={this} />;
         } else {
             const renderedView = this.renderTimerView();
             const sidebarContent = this.renderTimerViewSidebarContent();
@@ -285,7 +288,9 @@ export class LiveSplit extends React.Component<Props, State> {
     public openSplitsView() {
         this.setState({
             menu: { kind: MenuKind.Splits },
+            sidebarOpen: false,
         });
+        this.state.hotkeySystem.deactivate();
     }
 
     public openLayoutView() {
@@ -366,12 +371,10 @@ export class LiveSplit extends React.Component<Props, State> {
     }
 
     public async saveSplits() {
-        const lss = this.writeWith((t) => {
-            t.markAsUnmodified();
-            return t.saveAsLssBytes();
-        });
         try {
-            await Storage.storeSplits(lss);
+            await Storage.storeSplits((accessTimer) => {
+                this.writeWith(accessTimer);
+            });
         } catch (_) {
             toast.error("Failed to save the splits.");
         }
@@ -453,7 +456,7 @@ export class LiveSplit extends React.Component<Props, State> {
         } else {
             run.dispose();
         }
-        this.openTimerView(true);
+        this.openSplitsView();
     }
 
     public openLayoutEditor() {

--- a/src/ui/RunEditor.tsx
+++ b/src/ui/RunEditor.tsx
@@ -1416,22 +1416,23 @@ export class RunEditor extends React.Component<Props, State> {
 
     private async importComparison() {
         const [data, file] = await openFileAsArrayBuffer();
-        const result = LiveSplit.Run.parseArray(new Uint8Array(data), "", false);
-        if (!result.parsedSuccessfully()) {
-            toast.error("Couldn't parse the splits.");
-            return;
-        }
-        result.unwrap().with((run) => {
-            const comparisonName = prompt("Comparison Name:", file.name.replace(/\.[^/.]+$/, ""));
-            if (!comparisonName) {
+        LiveSplit.Run.parseArray(new Uint8Array(data), "", false).with((result) => {
+            if (!result.parsedSuccessfully()) {
+                toast.error("Couldn't parse the splits.");
                 return;
             }
-            const valid = this.props.editor.importComparison(run, comparisonName);
-            if (!valid) {
-                toast.error("The comparison could not be added. It may be a duplicate or a reserved name.");
-            } else {
-                this.update();
-            }
+            result.unwrap().with((run) => {
+                const comparisonName = prompt("Comparison Name:", file.name.replace(/\.[^/.]+$/, ""));
+                if (!comparisonName) {
+                    return;
+                }
+                const valid = this.props.editor.importComparison(run, comparisonName);
+                if (!valid) {
+                    toast.error("The comparison could not be added. It may be a duplicate or a reserved name.");
+                } else {
+                    this.update();
+                }
+            });
         });
     }
 

--- a/src/ui/SplitsSelection.tsx
+++ b/src/ui/SplitsSelection.tsx
@@ -6,6 +6,8 @@ import { toast } from "react-toastify";
 import { openFileAsArrayBuffer } from "../util/FileUtil";
 import { maybeDisposeAndThen } from "../util/OptionUtil";
 
+import "../css/SplitsSelection.scss";
+
 export interface Props {
     timer: SharedTimerRef,
     originalOpenedSplitsKey?: number,
@@ -51,64 +53,100 @@ export class SplitsSelection extends React.Component<Props, State> {
     }
 
     private renderView() {
-        if (this.state.splitsInfos === undefined) {
-            return <p>Loading...</p>;
+        let content;
+
+        if (this.state.splitsInfos == null) {
+            content = (
+                <div className="loading">
+                    <div className="fa fa-spinner fa-spin"></div>
+                    <div className="loading-text">Loading...</div>
+                </div>
+            );
+        } else {
+            content = (
+                <div className="splits-selection-container">
+                    <div className="main-actions">
+                        <button onClick={() => this.addNewSplits()}>
+                            <i className="fa fa-plus" aria-hidden="true" /> Add
+                        </button>
+                        <button onClick={() => this.importSplits()}>
+                            <i className="fa fa-download" aria-hidden="true" /> Import
+                        </button>
+                        <button onClick={() => this.importSplitsFromSplitsIo()}>
+                            <i className="fa fa-download" aria-hidden="true" /> From Splits.io
+                        </button>
+                    </div>
+                    <div className="splits-table">
+                        <div className="header-text">Active Splits</div>
+                        <div className="splits-rows">
+                            {
+                                this.state.splitsInfos
+                                    .filter(([key]) => key === this.state.openedSplitsKey)
+                                    .map(([key, info]) => this.renderActiveSplitsRow(key, info))
+                            }
+                        </div>
+                    </div>
+                    <div className="splits-table">
+                        <div className="header-text">Other Splits</div>
+                        <div className="splits-rows">
+                            {
+                                this.state.splitsInfos
+                                    .filter(([key]) => key !== this.state.openedSplitsKey)
+                                    .map(([key, info]) => this.renderOtherSplitsRow(key, info))
+                            }
+                        </div>
+                    </div>
+                </div>
+            );
         }
-        return <div>
-            <div>
-                <button onClick={() => this.addNewSplits()}>
-                    <i className="fa fa-plus" aria-hidden="true" /> Add
-                </button>
-                <button onClick={() => this.importSplits()}>
-                    <i className="fa fa-download" aria-hidden="true" /> Import
-                </button>
-                <button onClick={() => this.importSplitsFromSplitsIo()}>
-                    <i className="fa fa-download" aria-hidden="true" /> From Splits.io
-                </button>
+        return <div className="splits-selection">{content}</div>;
+    }
+
+    private renderActiveSplitsRow(key: number, info: SplitsInfo) {
+        return (
+            <div className="splits-row" key={key}>
+                {this.splitsTitle(info)}
+                <div className="splits-row-buttons">
+                    <button onClick={() => this.editSplits(key)}>
+                        <i aria-label="Edit Splits" className="fa fa-edit" aria-hidden="true" />
+                    </button>
+                    <button aria-label="Duplicate Splits" onClick={() => this.copySplits(key)}>
+                        <i className="fa fa-clone" aria-hidden="true" />
+                    </button>
+                </div>
             </div>
-            <div>
-                <h2>Active Splits</h2>
-                {
-                    this.state.splitsInfos
-                        .filter(([key]) => key === this.state.openedSplitsKey)
-                        .map(([key, info]) => {
-                            return <div key={key}>
-                                <button onClick={() => this.editSplits(key)}>
-                                    <i className="fa fa-edit" aria-hidden="true" />
-                                </button>
-                                <button onClick={() => this.copySplits(key)}>
-                                    <i className="fa fa-clone" aria-hidden="true" />
-                                </button>
-                                {info.game} - {info.category}
-                            </div>;
-                        })
-                }
+        );
+    }
+
+    private renderOtherSplitsRow(key: number, info: SplitsInfo) {
+        return (
+            <div className="splits-row" key={key}>
+                {this.splitsTitle(info)}
+                <div className="splits-row-buttons">
+                    <button aria-label="Open Splits" onClick={() => this.openSplits(key)}>
+                        <i className="fa fa-folder-open" aria-hidden="true" />
+                    </button>
+                    <button aria-label="Edit Splits" onClick={() => this.editSplits(key)}>
+                        <i className="fa fa-edit" aria-hidden="true" />
+                    </button>
+                    <button aria-label="Duplicate Splits" onClick={() => this.copySplits(key)}>
+                        <i className="fa fa-clone" aria-hidden="true" />
+                    </button>
+                    <button aria-label="Remove Splits" onClick={() => this.deleteSplits(key)}>
+                        <i className="fa fa-trash" aria-hidden="true" />
+                    </button>
+                </div>
             </div>
-            <div>
-                <h2>Other Splits</h2>
-                {
-                    this.state.splitsInfos
-                        .filter(([key]) => key !== this.state.openedSplitsKey)
-                        .map(([key, info]) => {
-                            return <div key={key}>
-                                <button onClick={() => this.openSplits(key)}>
-                                    <i className="fa fa-folder-open" aria-hidden="true" />
-                                </button>
-                                <button onClick={() => this.editSplits(key)}>
-                                    <i className="fa fa-edit" aria-hidden="true" />
-                                </button>
-                                <button onClick={() => this.copySplits(key)}>
-                                    <i className="fa fa-clone" aria-hidden="true" />
-                                </button>
-                                <button onClick={() => this.deleteSplits(key)}>
-                                    <i className="fa fa-trash" aria-hidden="true" />
-                                </button>
-                                {info.game} - {info.category}
-                            </div>;
-                        })
-                }
+        );
+    }
+
+    private splitsTitle(info: SplitsInfo) {
+        return (
+            <div className="splits-title-text">
+                <div className="splits-game">{info.game}</div>
+                <div className="splits-category">{info.category}</div>
             </div>
-        </div>;
+        );
     }
 
     private renderSidebarContent() {

--- a/src/ui/SplitsSelection.tsx
+++ b/src/ui/SplitsSelection.tsx
@@ -6,11 +6,12 @@ import {
 import { Run, Segment, SharedTimerRef, TimerPhase } from "../livesplit-core";
 import * as SplitsIO from "../util/SplitsIO";
 import { toast } from "react-toastify";
-import { openFileAsArrayBuffer, exportFile } from "../util/FileUtil";
+import { openFileAsArrayBuffer, exportFile, convertFileToArrayBuffer } from "../util/FileUtil";
 import { Option, maybeDisposeAndThen } from "../util/OptionUtil";
 import * as Storage from "../storage";
 
 import "../css/SplitsSelection.scss";
+import DragUpload from "./DragUpload";
 
 export interface EditingInfo {
     splitsKey?: number,
@@ -83,7 +84,11 @@ export class SplitsSelection extends React.Component<Props, State> {
                 </div>
             );
         }
-        return <div className="splits-selection">{content}</div>;
+        return <DragUpload
+            importSplits={this.importSplitsFromFile.bind(this)}
+        >
+            <div className="splits-selection">{content}</div>
+        </DragUpload>;
     }
 
     private async refreshDb() {
@@ -264,6 +269,11 @@ export class SplitsSelection extends React.Component<Props, State> {
         } catch (err) {
             toast.error(err.message);
         }
+    }
+
+    private async importSplitsFromFile(file: File) {
+        const splits = await convertFileToArrayBuffer(file);
+        this.importSplitsFromArrayBuffer(splits);
     }
 
     private async importSplitsFromArrayBuffer(buffer: [ArrayBuffer, File]) {

--- a/src/ui/SplitsSelection.tsx
+++ b/src/ui/SplitsSelection.tsx
@@ -88,14 +88,14 @@ export class SplitsSelection extends React.Component<Props, State> {
                             <i className="fa fa-download" aria-hidden="true" /> From Splits.io
                         </button>
                     </div>
-                    <table className="table splits-table">
-                        <tbody className="splits-rows table-body">
+                    <div className="splits-table">
+                        <div className="splits-rows">
                             {
                                 this.state.splitsInfos
                                     .map(([key, info]) => this.renderSavedSplitsRow(key, info))
                             }
-                        </tbody>
-                    </table>
+                        </div>
+                    </div>
                 </div>
             );
         }
@@ -130,11 +130,9 @@ export class SplitsSelection extends React.Component<Props, State> {
     private renderSavedSplitsRow(key: number, info: SplitsInfo) {
         const isOpened = key === this.props.openedSplitsKey;
         return (
-            <tr className={isOpened ? "splits-row selected" : "splits-row"} key={key}>
-                <td>
-                    {this.splitsTitle(info)}
-                </td>
-                <td className="splits-row-buttons">
+            <div className={isOpened ? "splits-row selected" : "splits-row"} key={key}>
+                {this.splitsTitle(info)}
+                <div className="splits-row-buttons">
                     {
                         isOpened
                             ? null
@@ -156,16 +154,16 @@ export class SplitsSelection extends React.Component<Props, State> {
                     <button aria-label="Remove Splits" onClick={() => this.deleteSplits(key)}>
                         <i className="fa fa-trash" aria-hidden="true" />
                     </button>
-                </td>
-            </tr>
+                </div>
+            </div>
         );
     }
 
     private splitsTitle(info: SplitsInfo) {
         return (
             <div className="splits-title-text">
-                <div className="splits-text">{info.game}</div>
-                <div className="splits-text">{info.category}</div>
+                <div className="splits-text splits-game">{info.game}</div>
+                <div className="splits-text splits-category">{info.category}</div>
             </div>
         );
     }

--- a/src/ui/SplitsSelection.tsx
+++ b/src/ui/SplitsSelection.tsx
@@ -164,8 +164,8 @@ export class SplitsSelection extends React.Component<Props, State> {
     private splitsTitle(info: SplitsInfo) {
         return (
             <div className="splits-title-text">
-                <div className="splits-game">{info.game}</div>
-                <div className="splits-category">{info.category}</div>
+                <div className="splits-text">{info.game}</div>
+                <div className="splits-text">{info.category}</div>
             </div>
         );
     }

--- a/src/ui/SplitsSelection.tsx
+++ b/src/ui/SplitsSelection.tsx
@@ -1,0 +1,130 @@
+import * as React from "react";
+import { getSplitsInfos, SplitsInfo } from "../storage";
+
+export interface Props {
+    callbacks: Callbacks,
+}
+
+interface State {
+    splitsInfos?: Array<[number, SplitsInfo]>,
+}
+
+interface Callbacks {
+    openTimerView(arg0: boolean): void;
+    loadDefaultSplits(): void;
+    uploadToSplitsIO(): void;
+    openFromSplitsIO(): void;
+    exportSplits(): void;
+    importSplits(): void;
+    saveSplits(): void;
+    openRunEditor(): void;
+    renderViewWithSidebar(renderedView: JSX.Element, sidebarContent: JSX.Element): JSX.Element,
+}
+
+export class SplitsSelection extends React.Component<Props, State> {
+    constructor(props: Props) {
+        getSplitsInfos().then(async (splitsInfos) => {
+            this.setState({
+                splitsInfos,
+            });
+        });
+
+        super(props);
+
+        this.state = {};
+    }
+
+    public render() {
+        const renderedView = this.renderView();
+        const sidebarContent = this.renderSidebarContent();
+        return this.props.callbacks.renderViewWithSidebar(renderedView, sidebarContent);
+    }
+
+    private renderView() {
+        if (this.state.splitsInfos === undefined) {
+            return <p>Loading...</p>;
+        }
+        return <div>
+            <div>
+                <button onClick={() => this.addNewSplits()}>
+                    <i className="fa fa-plus" aria-hidden="true" /> Add
+                </button>
+                <button onClick={() => this.importSplits()}>
+                    <i className="fa fa-download" aria-hidden="true" /> Import
+                </button>
+            </div>
+            <div>
+                {
+                    this.state.splitsInfos.map(([key, info]) => {
+                        return <div>
+                            <button onClick={() => this.editSplits(key)}>
+                                <i className="fa fa-edit" aria-hidden="true" />
+                            </button>
+                            <button onClick={() => this.copySplits(key)}>
+                                <i className="fa fa-clone" aria-hidden="true" />
+                            </button>
+                            <button onClick={() => this.deleteSplits(key)}>
+                                <i className="fa fa-trash" aria-hidden="true" />
+                            </button>
+                            {info.game} - {info.category}
+                        </div>;
+                    })
+                }
+            </div>
+        </div>;
+    }
+
+    private renderSidebarContent() {
+        return (
+            <div className="sidebar-buttons">
+                <h1>Splits</h1>
+                <hr />
+                <button onClick={(_) => this.props.callbacks.openRunEditor()}>
+                    <i className="fa fa-edit" aria-hidden="true" /> Edit
+                </button>
+                <button onClick={(_) => this.props.callbacks.saveSplits()}>
+                    <i className="fa fa-save" aria-hidden="true" /> Save
+                </button>
+                <button onClick={(_) => this.props.callbacks.importSplits()}>
+                    <i className="fa fa-download" aria-hidden="true" /> Import
+                </button>
+                <button onClick={(_) => this.props.callbacks.exportSplits()}>
+                    <i className="fa fa-upload" aria-hidden="true" /> Export
+                </button>
+                <button onClick={(_) => this.props.callbacks.openFromSplitsIO()}>
+                    <i className="fa fa-download" aria-hidden="true" /> From Splits.io
+                </button>
+                <button onClick={(_) => this.props.callbacks.uploadToSplitsIO()}>
+                    <i className="fa fa-upload" aria-hidden="true" /> Upload to Splits.io
+                </button>
+                <button onClick={(_) => this.props.callbacks.loadDefaultSplits()}>
+                    <i className="fa fa-sync" aria-hidden="true" /> Default
+                </button>
+                <hr />
+                <button onClick={(_) => this.props.callbacks.openTimerView(true)}>
+                    <i className="fa fa-caret-left" aria-hidden="true" /> Back
+                </button>
+            </div>
+        );
+    }
+
+    private editSplits(_key: number): void {
+        throw new Error("Method not implemented.");
+    }
+
+    private copySplits(_key: number): void {
+        throw new Error("Method not implemented.");
+    }
+
+    private deleteSplits(_key: number): void {
+        throw new Error("Method not implemented.");
+    }
+
+    private importSplits() {
+        throw new Error("Method not implemented.");
+    }
+
+    private addNewSplits() {
+        console.log("hi");
+    }
+}

--- a/src/ui/SplitsSelection.tsx
+++ b/src/ui/SplitsSelection.tsx
@@ -74,14 +74,17 @@ export class SplitsSelection extends React.Component<Props, State> {
                             <i className="fa fa-download" aria-hidden="true" /> From Splits.io
                         </button>
                     </div>
-                    <div className="splits-table">
-                        <div className="splits-rows">
-                            {
-                                this.state.splitsInfos
-                                    .map(([key, info]) => this.renderSavedSplitsRow(key, info))
-                            }
+                    {
+                        this.state.splitsInfos?.length > 0 &&
+                        <div className="splits-table">
+                            <div className="splits-rows">
+                                {
+                                    this.state.splitsInfos
+                                        .map(([key, info]) => this.renderSavedSplitsRow(key, info))
+                                }
+                            </div>
                         </div>
-                    </div>
+                    }
                 </div>
             );
         }

--- a/src/ui/SplitsSelection.tsx
+++ b/src/ui/SplitsSelection.tsx
@@ -133,8 +133,8 @@ export class SplitsSelection extends React.Component<Props, State> {
     private splitsTitle(info: SplitsInfo) {
         return (
             <div className="splits-title-text">
-                <div className="splits-text splits-game">{info.game}</div>
-                <div className="splits-text splits-category">{info.category}</div>
+                <div className="splits-text splits-game">{info.game || "Untitled"}</div>
+                <div className="splits-text splits-category">{info.category || "—"}</div>
             </div>
         );
     }

--- a/src/util/SplitsIO.ts
+++ b/src/util/SplitsIO.ts
@@ -90,11 +90,11 @@ export async function downloadById(id: string): Promise<Run> {
         DownloadError.InvalidBuffer,
     );
 
-    const result = Run.parseArray(new Uint8Array(data), "", false);
-
-    if (result.parsedSuccessfully()) {
-        return result.unwrap();
-    } else {
-        throw DownloadError.FailedParsing;
-    }
+    return Run.parseArray(new Uint8Array(data), "", false).with((result) => {
+        if (result.parsedSuccessfully()) {
+            return result.unwrap();
+        } else {
+            throw DownloadError.FailedParsing;
+        }
+    });
 }

--- a/test/rendering-test.js
+++ b/test/rendering-test.js
@@ -138,7 +138,7 @@ describe("Layout Rendering Tests", function() {
     testRendering("default", "default", "________8AAD8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADgAAD_________");
     testRendering("default", "pmw3", "f_wAb__mX2AG3-gGUdgGSkgOX3AOW9gOX-APVlwOH_APX8AO1uAPUnAOX1AOXLAeHvAeX_wf__AfAAAAAABgAAD_AAB_____");
     testRendering("splits_two_rows", "celeste", "f8AAcAAHf8AA____d4AAcAAHf_gAcAAPd_AAYAAHf4AA____f4AAYAAH__AA____Z_gAYAAHf_8A9VVfb_wAcAAPf_AAYAAP");
-    testRendering("splits_with_labels", "celeste", "AABAAABMAADPAADPAADP____7AAP_wAP_wAP_wAPwgAA____QAAH2oAP_4AH34APX4AA____wAAP9EAP38AP38AP38AAAAAA");
+    testRendering("splits_with_labels", "celeste", "AABAAABMAADPAADPAADP____7AAP_wAP_wAP_wAPwgAA____wAAH2oAP_4AH34APX4AA____wAAP9EAP38AP38AP38AAAAAA");
     testRendering("title_centered_no_game_icon", "celeste", "________AAAAADQAAHQAAH4A______3_____AAAAAAAAAAAA____AAkAAL8DAP8DAP8DAP8D_________-n9AAAAAAAAAAAA");
     testRendering("title_centered_with_game_icon", "celeste", "________AAAAIB0AIB8AYB8A________cB8AcAAAcAAAcAAAcAAAcAZAcC_DcD_DcD_DcD_D_________9Z9cAAAAAAAAAAA");
     testRendering("title_left_no_attempt_count", "celeste", "________AAAA-AAA-AAA-AAA____________AAAAAAAAAAAA____CQAA_wAA_4AA_4AA_4AA________qf__AAAAAAAAAAAA");

--- a/test/rendering-test.js
+++ b/test/rendering-test.js
@@ -45,6 +45,7 @@ describe("Layout Rendering Tests", function() {
     const loadFile = async (filePath) => {
         const inputElement = await findElement(By.id("file-input"));
         await inputElement.sendKeys(path.resolve(filePath));
+        await driver.sleep(500);
     }
 
     before(async () => {
@@ -86,6 +87,7 @@ describe("Layout Rendering Tests", function() {
             await clickElement(By.xpath(".//button[contains(text(), 'Splits')]"));
             await clickElement(By.xpath(".//button[contains(text(), 'Import')]"));
             await loadFile(`${SPLITS_FOLDER}/${splitsName}.lss`);
+            await clickElement(By.xpath("(.//button[contains(@aria-label, 'Open Splits')])[last()]"));
             await clickElement(By.xpath(".//button[contains(text(), 'Back')]"));
     
             const layoutElement = await findElement(By.className("layout"));

--- a/tslint.json
+++ b/tslint.json
@@ -41,7 +41,7 @@
             "check-format",
             "allow-leading-underscores"
         ],
-        "array-type": false
+        "array-type": [true, "array-simple"]
     },
     "rulesDirectory": []
 }

--- a/tslint.json
+++ b/tslint.json
@@ -40,7 +40,8 @@
         "variable-name": [
             "check-format",
             "allow-leading-underscores"
-        ]
+        ],
+        "array-type": false
     },
     "rulesDirectory": []
 }


### PR DESCRIPTION
Here's a draft PR for what will be the splits selection view. There's some initial changes to the IndexedDB and already shows some very unstyled splits selection view.

- [x] Changes to the IndexedDB
- [x] Basic splits selection
- [x] Basic styling
- [x] Splits Editor for runs that are not loaded
- [x] Modify the open splits key when switching between splits
- [x] Have a notion of an undefined / null splits key for splits that are open, but have never been saved to the DB.
- [x] Store the splits key in the IndexedDB settings table.
~~Handle all the potential race conditions like downloading splits and then closing the splits selection view while the download is happening.~~