### PR TITLE
Update pngjs to 4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1191,6 +1191,14 @@
           "dev": true,
           "requires": {
             "pngjs": "^3.0.0"
+          },
+          "dependencies": {
+            "pngjs": {
+              "version": "3.4.0",
+              "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
+              "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
+              "dev": true
+            }
           }
         },
         "regenerator-runtime": {
@@ -1961,6 +1969,12 @@
           "version": "3.6.4",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
           "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==",
+          "dev": true
+        },
+        "pngjs": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
+          "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
           "dev": true
         },
         "regenerator-runtime": {
@@ -8131,6 +8145,14 @@
       "dev": true,
       "requires": {
         "pngjs": "^3.2.0"
+      },
+      "dependencies": {
+        "pngjs": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
+          "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
+          "dev": true
+        }
       }
     },
     "parse5": {
@@ -8279,6 +8301,14 @@
       "dev": true,
       "requires": {
         "pngjs": "^3.4.0"
+      },
+      "dependencies": {
+        "pngjs": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
+          "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
+          "dev": true
+        }
       }
     },
     "pkg-dir": {
@@ -8291,9 +8321,9 @@
       }
     },
     "pngjs": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
-      "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-4.0.0.tgz",
+      "integrity": "sha512-607/ROF2oFEQoL+cQD894iYHdZhXWB8lISaR4MWI8VUgHPViC7FODcIySWCdnkkdrVD4YrfVU8Rmd6ZlMkq8Pw==",
       "dev": true
     },
     "portfinder": {
@@ -9238,6 +9268,12 @@
               "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.2.0.tgz",
               "integrity": "sha1-U+RI7J0mPmgyZkZ+lELSxaLvVII=",
               "dev": true
+            },
+            "pngjs": {
+              "version": "3.4.0",
+              "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
+              "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
+              "dev": true
             }
           }
         },
@@ -9260,6 +9296,14 @@
           "dev": true,
           "requires": {
             "pngjs": "^3.0.0"
+          },
+          "dependencies": {
+            "pngjs": {
+              "version": "3.4.0",
+              "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
+              "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
+              "dev": true
+            }
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "moment": "^2.24.0",
     "node-fetch": "^2.6.0",
     "pixelmatch": "^5.1.0",
-    "pngjs": "^3.4.0",
+    "pngjs": "^4.0.0",
     "sass": "^1.24.4",
     "sass-loader": "^8.0.2",
     "selenium-webdriver": "^4.0.0-alpha.5",


### PR DESCRIPTION
The update in https://github.com/LiveSplit/LiveSplitOne/pull/298 also bumped the pngjs version that a bunch of other packages use to 4.0.0, even though they don't support it.