### PR TITLE
Install wasm-bindgen from tool-cache again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,11 +59,11 @@ jobs:
         cmake .
         make wasm-opt
 
-    # FIXME: Use actions-rs/install@v0.1 again once it can handle wasm-bindgen
     - name: Install wasm-bindgen
-      run: |
-        set -e
-        cargo install wasm-bindgen-cli
+      uses: actions-rs/install@v0.1
+      with:
+        crate: wasm-bindgen-cli
+        use-tool-cache: true
 
     - name: Install npm packages
       run: |


### PR DESCRIPTION
The upstream issue has been closed, so this should work again.