### PR TITLE
Fix empty columns affecting columns to the left

### DIFF
--- a/src/layout/Split.tsx
+++ b/src/layout/Split.tsx
@@ -57,6 +57,8 @@ export default class Split extends React.Component<Props> {
             const column = this.props.split.columns[i];
             if (!column.value) {
                 lastEmptyColumnIndex = i;
+            } else {
+                break;
             }
         }
 


### PR DESCRIPTION
Here are the splits and layout that reproduce the issue: [splits_and_layout.zip](https://github.com/LiveSplit/LiveSplitOne/files/4549823/splits_and_layout.zip). On `master`, all of the columns show up as empty, but with this fix, only the rightmost column is empty.

Fix #346 