### PR TITLE
Disambiguate the import in the WASM bindings

### DIFF
--- a/src/type-definitions/wasm.d.ts
+++ b/src/type-definitions/wasm.d.ts
@@ -1,0 +1,1 @@
+declare module '*.wasm'


### PR DESCRIPTION
It seems like wasm-bindgen generates both `livesplit_core_bg.wasm` as well as a `livesplit_core_bg.js` now. We used to import from `livesplit_core_bg` in our bindings before, which is now ambiguous.

Fixes #349 