### PR TITLE
Only re-render components when necessary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2811,6 +2811,14 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      },
+      "dependencies": {
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+          "dev": true
+        }
       }
     },
     "ajv-errors": {
@@ -5386,10 +5394,9 @@
       "dev": true
     },
     "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-      "dev": true
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
     },
     "fast-glob": {
       "version": "3.2.2",
@@ -9679,6 +9686,7 @@
             "jpeg-js": "^0.2.0",
             "load-bmfont": "^1.2.3",
             "mime": "^1.3.4",
+            "mkdirp": "0.5.1",
             "pixelmatch": "^4.0.0",
             "pngjs": "^3.0.0",
             "read-chunk": "^1.0.1",
@@ -9719,6 +9727,21 @@
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
           "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
           "dev": true
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
         },
         "pixelmatch": {
           "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@types/react-toggle": "^4.0.2",
     "commonmark": "^0.29.1",
     "commonmark-react-renderer": "^4.3.5",
+    "fast-deep-equal": "^3.1.1",
     "idb": "^5.0.2",
     "react": "^16.13.1",
     "react-color": "^2.18.0",

--- a/src/layout/Component.tsx
+++ b/src/layout/Component.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
-import { ComponentStateJson, LayoutStateJson } from "../livesplit-core";
+import deepEqual from "fast-deep-equal";
+import { ComponentStateJson, Color } from "../livesplit-core";
 import { assertNever } from "../util/OptionUtil";
 import BlankSpace from "./BlankSpace";
 import KeyValue from "./KeyValue";
@@ -13,7 +14,10 @@ import Title from "./Title";
 
 export interface Props {
     state: ComponentStateJson,
-    layoutState: LayoutStateJson,
+    layoutState: {
+        thin_separators_color: Color,
+        separators_color: Color,
+    },
     layoutWidth: number,
     componentId: string,
 }
@@ -55,5 +59,12 @@ export default class Component extends React.Component<Props> {
         } else {
             return assertNever(state);
         }
+    }
+
+    public shouldComponentUpdate(nextProps: Readonly<Props>): boolean {
+        return !deepEqual(nextProps.state, this.props.state) ||
+            !deepEqual(nextProps.layoutState, this.props.layoutState) ||
+            nextProps.layoutWidth !== this.props.layoutWidth ||
+            nextProps.componentId !== this.props.componentId;
     }
 }

--- a/src/layout/Layout.tsx
+++ b/src/layout/Layout.tsx
@@ -15,15 +15,18 @@ export interface Props {
 
 export default class Layout extends React.Component<Props> {
     public render() {
-        const layoutState = this.props.state;
+        const layoutState = {
+            thin_separators_color: this.props.state.thin_separators_color,
+            separators_color: this.props.state.separators_color,
+        };
         const counts = new Map<string, number>();
 
         return (
             <div
                 className="layout"
                 style={{
-                    background: gradientToCss(layoutState.background),
-                    color: colorToCss(layoutState.text_color),
+                    background: gradientToCss(this.props.state.background),
+                    color: colorToCss(this.props.state.text_color),
                     width: this.props.width,
                 }}
             >

--- a/src/layout/Separator.tsx
+++ b/src/layout/Separator.tsx
@@ -5,7 +5,9 @@ import { colorToCss } from "../util/ColorUtil";
 import "../css/Separator.scss";
 
 export interface Props {
-    layoutState: LiveSplit.LayoutStateJson,
+    layoutState: {
+        separators_color: LiveSplit.Color,
+    }
 }
 
 export default class Separator extends React.Component<Props> {

--- a/src/layout/Split.tsx
+++ b/src/layout/Split.tsx
@@ -1,15 +1,24 @@
 import * as React from "react";
+import deepEqual from "fast-deep-equal";
 import * as LiveSplit from "../livesplit-core";
 import { colorToCss, gradientToCss } from "../util/ColorUtil";
 import { Option } from "../util/OptionUtil";
 
 export interface Props {
-    splitsState: LiveSplit.SplitsComponentStateJson,
+    splitsState: {
+        has_icons: boolean,
+        show_thin_separators: boolean,
+        display_two_rows: boolean,
+        current_split_gradient: LiveSplit.Gradient,
+    },
     evenOdd: [Option<string>, Option<string>],
     split: LiveSplit.SplitStateJson,
     icon?: string,
     separatorInFrontOfSplit: boolean,
-    layoutState: LiveSplit.LayoutStateJson,
+    layoutState: {
+        thin_separators_color: LiveSplit.Color,
+        separators_color: LiveSplit.Color,
+    },
     visualSplitIndex: number,
 }
 
@@ -109,5 +118,15 @@ export default class Split extends React.Component<Props> {
                 </div>
             </span>
         );
+    }
+
+    public shouldComponentUpdate(nextProps: Readonly<Props>): boolean {
+        return !deepEqual(nextProps.splitsState, this.props.splitsState) ||
+            !deepEqual(nextProps.evenOdd, this.props.evenOdd) ||
+            !deepEqual(nextProps.split, this.props.split) ||
+            nextProps.icon !== this.props.icon ||
+            nextProps.separatorInFrontOfSplit !== this.props.separatorInFrontOfSplit ||
+            !deepEqual(nextProps.layoutState, this.props.layoutState) ||
+            nextProps.visualSplitIndex !== this.props.visualSplitIndex;
     }
 }

--- a/src/layout/Splits.tsx
+++ b/src/layout/Splits.tsx
@@ -9,7 +9,10 @@ import "../css/Splits.scss";
 
 export interface Props {
     state: LiveSplit.SplitsComponentStateJson,
-    layoutState: LiveSplit.LayoutStateJson,
+    layoutState: {
+        thin_separators_color: LiveSplit.Color,
+        separators_color: LiveSplit.Color,
+    },
 }
 
 export default class Splits extends React.Component<Props> {
@@ -40,6 +43,13 @@ export default class Splits extends React.Component<Props> {
             style.background = gradientToCss(background.Same);
         }
 
+        const splitsState = {
+            has_icons: this.props.state.has_icons,
+            show_thin_separators: this.props.state.show_thin_separators,
+            display_two_rows: this.props.state.display_two_rows,
+            current_split_gradient: this.props.state.current_split_gradient
+        };
+
         return (
             <div className="splits" style={style}>
                 {
@@ -53,7 +63,7 @@ export default class Splits extends React.Component<Props> {
                         <Split
                             evenOdd={evenOdd}
                             split={s}
-                            splitsState={this.props.state}
+                            splitsState={splitsState}
                             layoutState={this.props.layoutState}
                             icon={this.iconUrls[s.index]}
                             key={s.index.toString()}


### PR DESCRIPTION
Using `shouldComponentUpdate` allows us to skip updates unless the layout state actually changes. I'm not sure if we want to write our own comparison function rather than relying on `fast-deep-equal`, especially since our layout state values are guaranteed to be JSON. We could also just rely on `livesplit-core` to tell us whether a component needs to be updated.

### Benchmarks

Total scripting time when timer isn't running **(before)**: 19.6%
Total scripting time when timer isn't running **(after)**: 9.6%

Total scripting time when timer is running **(before)**: 21.5%
Total scripting time when timer is running **(after)**: 12.4%

[benchmarks.zip](https://github.com/LiveSplit/LiveSplitOne/files/4638639/benchmarks.zip)
