### PR TITLE
Improve Paint Times

### DIFF
--- a/src/css/Timer.scss
+++ b/src/css/Timer.scss
@@ -1,0 +1,4 @@
+.timer {
+    will-change: transform;
+    transform: translateZ(0);
+}

--- a/src/layout/Timer.tsx
+++ b/src/layout/Timer.tsx
@@ -3,6 +3,7 @@ import * as LiveSplit from "../livesplit-core";
 import { colorToCss, gradientToCss } from "../util/ColorUtil";
 
 import variables from "../css/variables.scss";
+import "../css/Timer.scss";
 
 const sidePadding = parseFloat(variables.sidePadding);
 
@@ -34,7 +35,7 @@ export function renderToSVG(
 
     return (
         <div
-            className={className}
+            className="timer"
             style={{
                 background: gradientToCss(state.background),
             }}


### PR DESCRIPTION
In most frames only the timer will be redrawn. By moving it into its own browser layer, we can reduce the amount of work the browser needs to do to redraw that layer.

You can read more about this here:

https://developers.google.com/web/fundamentals/performance/rendering/simplify-paint-complexity-and-reduce-paint-areas#promote_elements_that_move_or_fade

This improves our paint times from 0.71ms

![https://i.imgur.com/3Asf2gu.png](https://i.imgur.com/3Asf2gu.png)

to about 60us

![https://i.imgur.com/fL2xCES.png](https://i.imgur.com/fL2xCES.png)