### PR TITLE
Add parent params to twitch embeds

### DIFF
--- a/src/ui/Embed.tsx
+++ b/src/ui/Embed.tsx
@@ -60,5 +60,6 @@ function resolveYoutube(videoId: string): JSX.Element {
 }
 
 function resolveTwitch(videoId: string): JSX.Element {
-    return videoIframe(`https://player.twitch.tv/?video=${videoId}&autoplay=false`);
+    const domain = window.location.hostname;
+    return videoIframe(`https://player.twitch.tv/?video=${videoId}&parent=${domain}&autoplay=false`);
 }


### PR DESCRIPTION
I'm not sure how we can test this on one.livesplit.org without just deploying these changes.

Fix #379 