### PR TITLE
Apply all the recent performance improvements

### DIFF
--- a/src/layout/Title.tsx
+++ b/src/layout/Title.tsx
@@ -23,7 +23,7 @@ export default class Title extends React.Component<Props> {
         const finishedRunsExist = this.props.state.finished_runs !== null;
         const attemptsExist = this.props.state.attempts !== null;
         const line2 = this.props.state.line2;
-        const twoLines = line2 !== null;
+        const twoLines = line2.length !== 0;
         const showIcon = iconUrl !== "";
         const showAttempts = attemptsExist || finishedRunsExist;
 
@@ -72,7 +72,7 @@ export default class Title extends React.Component<Props> {
                         }
                         <div className={`title-category ${alignmentClass}`}>
                             <Abbreviated abbreviations={
-                                line2 !== null ? line2 : this.props.state.line1
+                                twoLines ? line2 : this.props.state.line1
                             } />
                         </div>
                         {

--- a/src/ui/LayoutView.tsx
+++ b/src/ui/LayoutView.tsx
@@ -1,10 +1,11 @@
 import * as React from "react";
-import { SharedTimer, Layout } from "../livesplit-core";
+import { SharedTimer, Layout, LayoutStateRefMut } from "../livesplit-core";
 import { TimerView } from "./TimerView";
 
 export interface Props {
     isDesktop: boolean,
     layout: Layout,
+    layoutState: LayoutStateRefMut,
     layoutWidth: number,
     renderWithSidebar: boolean,
     sidebarOpen: boolean,
@@ -33,6 +34,7 @@ export class LayoutView extends React.Component<Props> {
     public render() {
         const renderedView = <TimerView
             layout={this.props.layout}
+            layoutState={this.props.layoutState}
             layoutWidth={this.props.layoutWidth}
             isDesktop={this.props.isDesktop}
             renderWithSidebar={false}

--- a/src/ui/LiveSplit.tsx
+++ b/src/ui/LiveSplit.tsx
@@ -3,8 +3,7 @@ import Sidebar from "react-sidebar";
 import {
     HotkeySystem, Layout, LayoutEditor, Run, RunEditor,
     Segment, SharedTimer, Timer, TimerRef, TimerRefMut,
-    HotkeyConfig,
-    LayoutState,
+    HotkeyConfig, LayoutState,
 } from "../livesplit-core";
 import { convertFileToArrayBuffer, convertFileToString, exportFile, openFileAsString } from "../util/FileUtil";
 import { Option, assertNull, expect, maybeDisposeAndThen, panic } from "../util/OptionUtil";

--- a/src/ui/LiveSplit.tsx
+++ b/src/ui/LiveSplit.tsx
@@ -4,6 +4,7 @@ import {
     HotkeySystem, Layout, LayoutEditor, Run, RunEditor,
     Segment, SharedTimer, Timer, TimerRef, TimerRefMut,
     HotkeyConfig,
+    LayoutState,
 } from "../livesplit-core";
 import { convertFileToArrayBuffer, convertFileToString, exportFile, openFileAsString } from "../util/FileUtil";
 import { Option, assertNull, expect, maybeDisposeAndThen, panic } from "../util/OptionUtil";
@@ -53,6 +54,7 @@ export interface State {
     isBrowserSource: boolean,
     isDesktop: boolean,
     layout: Layout,
+    layoutState: LayoutState,
     layoutWidth: number,
     menu: Menu,
     openedSplitsKey?: number,
@@ -147,6 +149,7 @@ export class LiveSplit extends React.Component<Props, State> {
             isDesktop: isDesktop && !isBrowserSource,
             isBrowserSource,
             layout,
+            layoutState: LayoutState.new(),
             layoutWidth: props.layoutWidth,
             menu: { kind: MenuKind.Timer },
             sidebarOpen: false,
@@ -207,6 +210,7 @@ export class LiveSplit extends React.Component<Props, State> {
         );
         this.state.timer.dispose();
         this.state.layout.dispose();
+        this.state.layoutState.dispose();
         this.state.hotkeySystem?.dispose();
         this.isDesktopQuery.removeListener(this.mediaQueryChanged);
     }
@@ -240,6 +244,7 @@ export class LiveSplit extends React.Component<Props, State> {
         } else if (this.state.menu.kind === MenuKind.Timer) {
             return <TimerView
                 layout={this.state.layout}
+                layoutState={this.state.layoutState}
                 layoutWidth={this.state.layoutWidth}
                 isDesktop={this.state.isDesktop}
                 renderWithSidebar={true}
@@ -250,6 +255,7 @@ export class LiveSplit extends React.Component<Props, State> {
         } else if (this.state.menu.kind === MenuKind.Layout) {
             return <LayoutView
                 layout={this.state.layout}
+                layoutState={this.state.layoutState}
                 layoutWidth={this.state.layoutWidth}
                 isDesktop={this.state.isDesktop}
                 renderWithSidebar={true}

--- a/src/ui/TimerView.tsx
+++ b/src/ui/TimerView.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { toast } from "react-toastify";
 import {
     SharedTimer, TimerRef, TimerRefMut, Layout,
-    TimingMethod, TimeSpan,
+    TimingMethod, TimeSpan, LayoutStateRefMut,
 } from "../livesplit-core";
 import { Option } from "../util/OptionUtil";
 import DragUpload from "./DragUpload";
@@ -16,6 +16,7 @@ import "../css/TimerView.scss";
 export interface Props {
     isDesktop: boolean,
     layout: Layout,
+    layoutState: LayoutStateRefMut,
     layoutWidth: number,
     renderWithSidebar: boolean,
     sidebarOpen: boolean,
@@ -75,7 +76,7 @@ export class TimerView extends React.Component<Props, State> {
                 >
                     <AutoRefreshLayout
                         getState={() => this.readWith(
-                            (t) => this.props.layout.stateAsJson(t),
+                            (t) => this.props.layout.updateStateAsJson(this.props.layoutState, t),
                         )}
                         allowResize={this.props.isDesktop}
                         width={this.props.layoutWidth}


### PR DESCRIPTION
This updates livesplit-core which brings a variety of performance improvements:

- The Layout State is now being reused and thus most frames don't require any heap allocations anymore. However we still serialize everything over into a JSON string for now, which puts a lot of
  garbage on the JS heap.
  https://github.com/LiveSplit/livesplit-core/pull/334

- The frequent performance.now() calls we do, first look up the window and performance object every time. This tripled the amount of calls we do over into JavaScript, with each call into JavaScript being quite expensive in Chrome.
  https://github.com/LiveSplit/livesplit-core/pull/335

- By introducing a timer snapshot mechanism we further reduce the calls to performance.now() to a single time.
  https://github.com/LiveSplit/livesplit-core/pull/339

- Rust 1.44 regressed the performance of 128-bit integer multiplications by accident. Those are used for hashing the comparisons when looking up the times for a comparison, which is something we do very frequently. We however don't have many comparisons, so a simple Vec that we loop through is a bit faster, even in native code, and quite a bit faster in the web, because of the Rust 1.44 regression.
  https://github.com/LiveSplit/livesplit-core/pull/338

- We delay registering the Gamepad Hook Interval until the first gamepad button is registered. Most people won't use a gamepad, so the interval just wastes cpu time for no reason.
  https://github.com/LiveSplit/livesplit-core/pull/340