### PR TITLE
Add a threshold for the image hash comparison

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "hex64": "^0.4.0",
     "html-webpack-plugin": "^4.3.0",
     "imghash": "0.0.7",
+    "leven": "^3.1.0",
     "mocha": "^7.2.0",
     "moment": "^2.25.0",
     "node-fetch": "^2.6.0",


### PR DESCRIPTION
This PR bumps up the hash comparison threshold to 1 so that it doesn't fail randomly (which started happening with one of the recent Chrome updates).