### PR TITLE
Make hotkey button blur element always appear above the sidebar

### DIFF
--- a/src/ui/HotkeyButton.tsx
+++ b/src/ui/HotkeyButton.tsx
@@ -79,6 +79,7 @@ export default class HotkeyButton extends React.Component<Props, State> {
                             position: "fixed",
                             right: "0px",
                             top: "0px",
+                            zIndex: 5,
                         }}
                         onClick={() => this.blurButton()}
                     />


### PR DESCRIPTION
The Settings could previously be closed with the OK button while a hotkey was still being edited. This prevented the key press listener and gamepad interval from being removed properly, which resulted in "This is disposed" exceptions whenever a key was pressed. This change ensures that the hotkey button blur element covers the entire screen, which prevents exiting the Settings before a change to the hotkey is confirmed.

Fix #488 