### PR TITLE
Alert for #493

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -56,8 +56,9 @@ Those are known to block WebAssembly.`);
         if (e.name == "InvalidStateError") {
             alert(`Couldn't load LiveSplit One. \
 You may be in private browsing mode. \
-LiveSplitOne cannot run in this mode. \
-To run LiveSplitOne, please disable private browsing in your settings.\n`);
+LiveSplit One cannot store any splits, layouts, or other settings because of the limitations of the browser's private browsing mode. \
+These limitations may be lifted in the future. \
+To run LiveSplit One for now, please disable private browsing in your settings.\n`);
         }
     }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,40 +16,49 @@ async function run() {
     const ReactDOM = await ReactDOMImport;
     const { toast, ToastContainer } = await Toastify;
 
-    const {
-        splits,
-        splitsKey,
-        layout,
-        hotkeys,
-        layoutWidth,
-    } = await LiveSplit.loadStoredData();
-
     try {
-        ReactDOM.render(
-            <div>
-                <LiveSplit
-                    splits={splits}
-                    layout={layout}
-                    hotkeys={hotkeys}
-                    splitsKey={splitsKey}
-                    layoutWidth={layoutWidth}
-                />
-                <ToastContainer
-                    position={toast.POSITION.BOTTOM_RIGHT}
-                    toastClassName="toast-class"
-                    bodyClassName="toast-body"
-                    style={{
-                        textShadow: "none",
-                    }}
-                />
-            </div>,
-            document.getElementById("base"),
-        );
-    } catch (_) {
-        alert(`Couldn't load LiveSplit One. \
+        const {
+            splits,
+            splitsKey,
+            layout,
+            hotkeys,
+            layoutWidth,
+        } = await LiveSplit.loadStoredData();
+
+        try {
+            ReactDOM.render(
+                <div>
+                    <LiveSplit
+                        splits={splits}
+                        layout={layout}
+                        hotkeys={hotkeys}
+                        splitsKey={splitsKey}
+                        layoutWidth={layoutWidth}
+                    />
+                    <ToastContainer
+                        position={toast.POSITION.BOTTOM_RIGHT}
+                        toastClassName="toast-class"
+                        bodyClassName="toast-body"
+                        style={{
+                            textShadow: "none",
+                        }}
+                    />
+                </div>,
+                document.getElementById("base"),
+            );
+        } catch (_) {
+            alert(`Couldn't load LiveSplit One. \
 You may be using a browser that doesn't support WebAssembly. \
 Alternatively, you may be using an Adblocker like uBlock Origin. \
 Those are known to block WebAssembly.`);
+        }
+    } catch (e) {
+        if (e.name == "InvalidStateError") {
+            alert(`Couldn't load LiveSplit One. \
+You may be in private browsing mode. \
+LiveSplitOne cannot run in this mode. \
+To run LiveSplitOne, please disable private browsing in your settings.\n`);
+        }
     }
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -53,7 +53,7 @@ Alternatively, you may be using an Adblocker like uBlock Origin. \
 Those are known to block WebAssembly.`);
         }
     } catch (e) {
-        if (e.name == "InvalidStateError") {
+        if (e.name === "InvalidStateError") {
             alert(`Couldn't load LiveSplit One. \
 You may be in private browsing mode. \
 LiveSplit One cannot store any splits, layouts, or other settings because of the limitations of the browser's private browsing mode. \


### PR DESCRIPTION
IndexedDB is not usable at all when you are using Firefox's private browsing. Apparently they consider this a bug in Firefox and are currently intending to fix this: https://bugzilla.mozilla.org/show_bug.cgi?id=1639542
However, some discussion seems to indicate that it may be intentional and not be fixed: https://bugzilla.mozilla.org/show_bug.cgi?id=781982
Until (and if) they fix it, LiveSplitOne can display an alert telling users to turn off private browsing.