### PR TITLE
Activate the WASM Sign Extension Instructions

### DIFF
--- a/buildCore.js
+++ b/buildCore.js
@@ -14,6 +14,10 @@ execSync(
     {
         cwd: "livesplit-core",
         stdio: "inherit",
+        env: {
+            ...process.env,
+            'RUSTFLAGS': '-C target-feature=+sign-ext',
+        },
     },
 );
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -48,9 +48,10 @@ async function run() {
             );
         } catch (_) {
             alert(`Couldn't load LiveSplit One. \
-You may be using a browser that doesn't support WebAssembly. \
-Alternatively, you may be using an Adblocker like uBlock Origin. \
-Those are known to block WebAssembly.`);
+You may be using a browser that is not up to date. \
+Please update your browser or your iOS version and try again. \
+Another reason might be that a browser extension, such as an adblocker, \
+is blocking access to important scripts.`);
         }
     } catch (e) {
         if (e.name === "InvalidStateError") {


### PR DESCRIPTION
All browsers now support the new WebAssembly Sign Extension Instructions which improve code that casts around between small integer types. We'd like to activate a bunch more new WASM instructions, but Safari is really lacking behind quite a lot. Even just activating these requires the latest Safari / iOS version that came out just a month ago. We notify the user to update their browser / iOS version in case they have an outdated browser. iOS updates on its own over night, so I believe most people should be on the latest version and shouldn't have any problem updating in case it didn't happen yet.

Resolves #528 (mostly at least, only one feature, but we can just add more over time as they become available)