### PR TITLE
Inline the main JS bundle into the HTML

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5280,6 +5280,12 @@
       "integrity": "sha512-8nxjcBcd8wovbeKx7h3wTji4e6+rhaVuPNpMqwWgnHh+N9ToqsCs6XztWRBPQ+UtzsoMAdKZtUENoVzU/EMtZA==",
       "dev": true
     },
+    "html-inline-script-webpack-plugin": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/html-inline-script-webpack-plugin/-/html-inline-script-webpack-plugin-2.0.1.tgz",
+      "integrity": "sha512-bEAVIZUvEx1z3GzBJrZhNnnYXqitwpLRCnF8wS4gAgyednJcJle7OkGPw1De88wIs8pXjC9hT7Mw42gjejWX2Q==",
+      "dev": true
+    },
     "html-minifier-terser": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "favicons-webpack-plugin": "^5.0.2",
     "file-loader": "^6.2.0",
     "hex64": "^0.4.0",
+    "html-inline-script-webpack-plugin": "^2.0.1",
     "html-webpack-plugin": "^5.3.2",
     "imghash": "0.0.9",
     "leven": "^3.1.0",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,66 +2,6 @@ if (process.env.NODE_ENV === "production" && "serviceWorker" in navigator) {
     navigator.serviceWorker.register("/service-worker.js");
 }
 
-const UI = import("./ui/LiveSplit");
-const ReactImport = import("react");
-const ReactDOMImport = import("react-dom");
-const Toastify = import("react-toastify");
-
-import "./css/font-awesome.css";
 import "./css/main.scss";
-
-async function run() {
-    const { LiveSplit } = await UI;
-    const React = await ReactImport;
-    const ReactDOM = await ReactDOMImport;
-    const { toast, ToastContainer } = await Toastify;
-
-    try {
-        const {
-            splits,
-            splitsKey,
-            layout,
-            hotkeys,
-            layoutWidth,
-        } = await LiveSplit.loadStoredData();
-
-        try {
-            ReactDOM.render(
-                <div>
-                    <LiveSplit
-                        splits={splits}
-                        layout={layout}
-                        hotkeys={hotkeys}
-                        splitsKey={splitsKey}
-                        layoutWidth={layoutWidth}
-                    />
-                    <ToastContainer
-                        position={toast.POSITION.BOTTOM_RIGHT}
-                        toastClassName="toast-class"
-                        bodyClassName="toast-body"
-                        style={{
-                            textShadow: "none",
-                        }}
-                    />
-                </div>,
-                document.getElementById("base"),
-            );
-        } catch (_) {
-            alert(`Couldn't load LiveSplit One. \
-You may be using a browser that is not up to date. \
-Please update your browser or your iOS version and try again. \
-Another reason might be that a browser extension, such as an adblocker, \
-is blocking access to important scripts.`);
-        }
-    } catch (e) {
-        if (e.name === "InvalidStateError") {
-            alert(`Couldn't load LiveSplit One. \
-You may be in private browsing mode. \
-LiveSplit One cannot store any splits, layouts, or other settings because of the limitations of the browser's private browsing mode. \
-These limitations may be lifted in the future. \
-To run LiveSplit One for now, please disable private browsing in your settings.\n`);
-        }
-    }
-}
-
-run();
+import("./main");
+import("./css/font-awesome.css");

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,51 @@
+import { LiveSplit } from "./ui/LiveSplit";
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+import { toast, ToastContainer } from "react-toastify";
+
+try {
+    const {
+        splits,
+        splitsKey,
+        layout,
+        hotkeys,
+        layoutWidth,
+    } = await LiveSplit.loadStoredData();
+
+    try {
+        ReactDOM.render(
+            <div>
+                <LiveSplit
+                    splits={splits}
+                    layout={layout}
+                    hotkeys={hotkeys}
+                    splitsKey={splitsKey}
+                    layoutWidth={layoutWidth}
+                />
+                <ToastContainer
+                    position={toast.POSITION.BOTTOM_RIGHT}
+                    toastClassName="toast-class"
+                    bodyClassName="toast-body"
+                    style={{
+                        textShadow: "none",
+                    }}
+                />
+            </div>,
+            document.getElementById("base"),
+        );
+    } catch (_) {
+        alert(`Couldn't load LiveSplit One. \
+You may be using a browser that is not up to date. \
+Please update your browser or your iOS version and try again. \
+Another reason might be that a browser extension, such as an adblocker, \
+is blocking access to important scripts.`);
+    }
+} catch (e) {
+    if (e.name === "InvalidStateError") {
+        alert(`Couldn't load LiveSplit One. \
+You may be in private browsing mode. \
+LiveSplit One cannot store any splits, layouts, or other settings because of the limitations of the browser's private browsing mode. \
+These limitations may be lifted in the future. \
+To run LiveSplit One for now, please disable private browsing in your settings.\n`);
+    }
+}

--- a/src/type-definitions/scss.d.ts
+++ b/src/type-definitions/scss.d.ts
@@ -1,1 +1,2 @@
 declare module '*.scss'
+declare module '*.css'

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 module.exports = async (env, argv) => {
     const HtmlWebpackPlugin = require("html-webpack-plugin");
+    const HtmlInlineScriptPlugin = require('html-inline-script-webpack-plugin');
     const FaviconsWebpackPlugin = require("favicons-webpack-plugin");
     const { CleanWebpackPlugin } = require("clean-webpack-plugin");
     const WorkboxPlugin = require("workbox-webpack-plugin");
@@ -51,6 +52,7 @@ module.exports = async (env, argv) => {
         output: {
             filename: "[name].js",
             path: distPath,
+            publicPath: '',
         },
 
         devtool: isProduction ? undefined : "source-map",
@@ -93,14 +95,16 @@ module.exports = async (env, argv) => {
                 CONTRIBUTORS_LIST: JSON.stringify(contributorsList),
             }),
             ...(isProduction ? [
+                new HtmlInlineScriptPlugin(['bundle.js']),
                 new WorkboxPlugin.GenerateSW({
                     clientsClaim: true,
                     skipWaiting: true,
                     maximumFileSizeToCacheInBytes: 100 * 1024 * 1024,
                     exclude: [
-                        /^assets\//,
-                        /.*\.LICENSE\.txt/,
+                        /^assets/,
+                        /\.LICENSE\.txt$/,
                     ],
+
                     runtimeCaching: [{
                         urlPattern: (context) => {
                             return self.origin === context.url.origin &&
@@ -158,7 +162,8 @@ module.exports = async (env, argv) => {
         },
 
         experiments: {
-            asyncWebAssembly: true,
+            syncWebAssembly: true,
+            topLevelAwait: true,
         },
 
         mode: isProduction ? "production" : "development",


### PR DESCRIPTION
By inlining a tiny amount of JS into the HTML, we can request the WASM and other JS bundles much sooner, reducing the latency a bit. This also inlines the most important styling, so that the loading screen is always properly styled. We unfortunately have to use `syncWebAssembly` here as it allows requesting the WASM file sooner than the other setting. It's not a whole lot sooner, so once they remove the setting, we can switch back without taking too much of a hit. Another thing that I did here is that the JS that we are loading is now a bigger bundle instead of smaller ones. We need to await all of them anyway, so I feel like splitting them only means that less optimizations can be done and more requests need to be sent. So there's less, but bigger bundles now. However one thing that I'm not 100% sure is to what degree JS can be compiled while streaming. If it can't, then requesting smaller chunks so the browser can precompile them while downloading others, might be faster.

Resolves #572 