### PR TITLE
Fix Hotkeys not being set properly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         git -C binaryen pull || git clone https://github.com/WebAssembly/binaryen binaryen
         cd binaryen
         cmake .
-        make wasm-opt
+        make -j wasm-opt
 
     # FIXME: Use actions-rs/install@v0.1 again once it can handle wasm-bindgen
     - name: Install wasm-bindgen


### PR DESCRIPTION
When changing the hotkeys in the settings, it doesn't properly set the hotkeys anymore. This is because of a refactor that we merged in `livesplit-core` that unregisters the hotkeys while the `HotkeySystem` is deactivated. The hotkey settings deactivate the hotkeys so you don't accidentally split / reset / ... the timer in the background. The bug was that it was completely impossible to set hotkeys while they are deactivated.

Fixes #575 