### PR TITLE
Use `make -j2` instead of `make -j`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         git -C binaryen pull || git clone https://github.com/WebAssembly/binaryen binaryen
         cd binaryen
         cmake .
-        make -j wasm-opt
+        make -j2 wasm-opt
 
     # FIXME: Use actions-rs/install@v0.1 again once it can handle wasm-bindgen
     - name: Install wasm-bindgen


### PR DESCRIPTION
Apparently `-j` completely crashes the GitHub Actions runner (or at least makes it hang).