### PR TITLE
Use the latest LTS version of node.js in the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,9 @@ jobs:
         key: ${{ runner.os }}-target-${{ env.CURRENT_TWO_WEEKS }}
 
     - name: Install Node
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2.3.0
       with:
-        node-version: '12.x' # FIXME: https://github.com/actions/setup-node/issues/26
+        node-version: 'lts/*'
 
     - name: Install Rust
       uses: hecrj/setup-rust-action@v1


### PR DESCRIPTION
Looks like the action now supports specifying that you just want the latest LTS version without having to actually specify the specific
version.