### PR TITLE
Fix ability to have multiple active websocket connections

### DIFF
--- a/src/ui/TimerView.tsx
+++ b/src/ui/TimerView.tsx
@@ -51,6 +51,10 @@ export class TimerView extends React.Component<Props, State> {
         };
     }
 
+    componentWillUnmount() {
+        this.connection?.close();
+    }
+
     public render() {
         const renderedView = this.renderView();
         if (this.props.renderWithSidebar) {


### PR DESCRIPTION
👋 small fix - noticed that there's a bug which allows multiple websocket connections to be open at once, potentially resulting in duplicate instructions:

- go to the main timer screen
- open a connection
- navigate away (for example, click "Splits") --> connection is not closed
- open another connection
- check Devtools Network tab --> shows two connections

This PR just closes the active connection on unmount of `TimerView` if it exists.