### PR TITLE
Resolve Key Codes with `livesplit-core`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "build": "webpack",
     "build:core": "node buildCore.js",
-    "build:core:production": "node buildCore.js --production",
-    "build:core:deploy": "node buildCore.js --production --nightly",
+    "build:core:release": "node buildCore.js --release",
+    "build:core:deploy": "node buildCore.js --max-opt --nightly",
     "lint": "tslint --project tsconfig.json",
     "publish": "webpack --mode production",
     "serve": "webpack serve",

--- a/src/ui/HotkeyButton.tsx
+++ b/src/ui/HotkeyButton.tsx
@@ -1,27 +1,11 @@
 import * as React from "react";
-import { Option, map } from "../util/OptionUtil";
+import { Option, map, expect } from "../util/OptionUtil";
+import { hotkeySystem } from "./LiveSplit";
 
 import "../css/HotkeyButton.scss";
 
-let layoutMap: { get: (keyCode: string) => string | undefined; } | null = null;
-
-(navigator as any).keyboard?.getLayoutMap()?.then((m: any) => {
-    layoutMap = m;
-});
-
 function resolveKey(keyCode: string): string {
-    if (layoutMap == null) {
-        return keyCode;
-    }
-    const lowercase = layoutMap.get(keyCode);
-    if (lowercase === undefined) {
-        return keyCode;
-    }
-    if (lowercase === "ß") {
-        // ß uppercases to SS, but that's not what's on the keyboard.
-        return lowercase;
-    }
-    return lowercase.toUpperCase();
+    return expect(hotkeySystem, "The Hotkey System should always be initialized.").resolve(keyCode);
 }
 
 export interface Props {

--- a/src/ui/LiveSplit.tsx
+++ b/src/ui/LiveSplit.tsx
@@ -63,6 +63,8 @@ export interface State {
     timer: SharedTimer,
 }
 
+export let hotkeySystem: Option<HotkeySystem> = null;
+
 export class LiveSplit extends React.Component<Props, State> {
     public static async loadStoredData() {
         const splitsKey = await Storage.loadSplitsKey();
@@ -95,7 +97,6 @@ export class LiveSplit extends React.Component<Props, State> {
             "The Default Run should be a valid Run",
         ).intoShared();
 
-        let hotkeySystem: Option<HotkeySystem> = null;
         const hotkeys = props.hotkeys;
         try {
             if (hotkeys !== undefined) {


### PR DESCRIPTION
This updates `livesplit-core` such that we can resolve the key codes with its built-in resolving code. Also since `livesplit-core` introduced a `max-opt` profile, we make use of that now and on top of that also introduce `virtual-function-elimination` for the nightly / CI builds. This is an additional LLVM pass that tries to eliminate as many function pointers as possible by analyzing the whole program. Locally this reduced the size of the function pointer table from around 500 to around 400 entries. There's also a flag for using WebAssembly SIMD instructions, as that works perfectly fine on all browsers except Safari. Of course we won't use it for deploying until Safari supports those instructions, but it may be useful for some local testing.