### PR TITLE
Fix `livesplit-core` bindings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,18 +12,12 @@ jobs:
 
     steps:
     - name: Checkout commit
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: recursive
 
     - name: Set CURRENT_TWO_WEEKS for use in cache keys
       run: echo "CURRENT_TWO_WEEKS=$(($(date +%-V) / 2))" >> $GITHUB_ENV
-
-    - name: Cache Cargo
-      uses: actions/cache@v1
-      with:
-        path: ~/.cargo
-        key: ${{ runner.os }}-cargo-${{ env.CURRENT_TWO_WEEKS }}
 
     - name: Cache binaryen
       if: github.repository == 'LiveSplit/LiveSplitOne' && github.ref == 'refs/heads/master'
@@ -48,37 +42,42 @@ jobs:
       with:
         rust-version: nightly
         components: rust-src
-
-    - name: Install target
-      run: rustup target add wasm32-unknown-unknown
+        targets: wasm32-unknown-unknown
 
     - name: Install optimizers
       if: github.repository == 'LiveSplit/LiveSplitOne' && github.ref == 'refs/heads/master'
       run: |
-        set -e
         cd $HOME
         git -C binaryen pull || git clone --recursive https://github.com/WebAssembly/binaryen binaryen
         cd binaryen
         cmake .
         make -j2 wasm-opt
 
-    # FIXME: Use actions-rs/install@v0.1 again once it can handle wasm-bindgen
-    - name: Install wasm-bindgen
+    - name: Choose wasm-bindgen-cli version
+      run: echo "version=$(cd livesplit-core && cargo tree -i wasm-bindgen --features wasm-web --target wasm32-unknown-unknown --depth 0 | sed 's/.* v//g')" >> $GITHUB_OUTPUT
+      id: wasm-bindgen
+
+    - name: Download wasm-bindgen-cli
+      uses: robinraju/release-downloader@v1.7
+      with:
+        repository: "rustwasm/wasm-bindgen"
+        tag: ${{ steps.wasm-bindgen.outputs.version }}
+        fileName: "wasm-bindgen-${{ steps.wasm-bindgen.outputs.version }}-x86_64-unknown-linux-musl.tar.gz"
+        out-file-path: "/home/runner/.cargo/bin"
+
+    - name: Install wasm-bindgen-cli
       run: |
-        set -e
-        cargo install wasm-bindgen-cli --debug
+        cd ~/.cargo/bin
+        tar -xzf wasm-bindgen-${{ steps.wasm-bindgen.outputs.version }}-x86_64-unknown-linux-musl.tar.gz
+        mv wasm-bindgen-${{ steps.wasm-bindgen.outputs.version }}-x86_64-unknown-linux-musl/wasm* .
 
     - name: Install npm packages
-      run: |
-        set -e
-        npm ci
+      run: npm ci
       env:
         DETECT_CHROMEDRIVER_VERSION: true
 
     - name: Build Core
-      run: |
-        set -e
-        npm run build:core:deploy
+      run: npm run build:core:deploy
 
     - name: Set up tslint matcher
       run: echo "::add-matcher::.github/workflows/tslint.json"
@@ -87,9 +86,7 @@ jobs:
       run: npm run lint
 
     - name: Build Frontend
-      run: |
-        set -e
-        npm run publish
+      run: npm run publish
 
     - name: Cache screenshots
       uses: actions/cache@v1
@@ -113,14 +110,12 @@ jobs:
     - name: Optimize
       if: github.repository == 'LiveSplit/LiveSplitOne' && github.ref == 'refs/heads/master'
       run: |
-        set -e
         WASM_FILE=$(ls dist/*.wasm)
         ~/binaryen/bin/wasm-opt -O4 "$WASM_FILE" -o "$WASM_FILE"
 
     - name: Add CNAME file
       if: github.repository == 'LiveSplit/LiveSplitOne' && github.ref == 'refs/heads/master'
-      run: |
-        cp ./.github/workflows/CNAME ./dist/CNAME
+      run: cp ./.github/workflows/CNAME ./dist/CNAME
 
     - name: Deploy
       if: github.repository == 'LiveSplit/LiveSplitOne' && github.ref == 'refs/heads/master'


### PR DESCRIPTION
Turns out that `wasm-bindgen` `v0.2.84` really requires us to import the main module as that's where they now dynamically set the wasm file. Additionally this improves our CI a little, by downloading a prebuilt version of `wasm-bindgen-cli`.