### PR TITLE
Implement Screen Wake Lock Support

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -27,6 +27,22 @@ try {
             layoutWidth,
         } = await LiveSplit.loadStoredData();
 
+        function requestWakeLock() {
+            try {
+                (navigator as any)?.wakeLock?.request("screen");
+            } catch {
+                // It's fine if it fails.
+            }
+        }
+
+        requestWakeLock();
+
+        document.addEventListener('visibilitychange', () => {
+            if (document.visibilityState === 'visible') {
+                requestWakeLock();
+            }
+        });
+
         ReactDOM.render(
             <div>
                 <LiveSplit


### PR DESCRIPTION
This attempts to use the Screen Wake Lock API to prevent the screen from turning off. This is available in iOS 16.4 now, however at least when adding the app to the home screen as a PWA, the functionality seems to be broken. Regardless, that's not something we can fix. We can instead simply always try to activate it and hopefully Apple fixes the bug soon.

https://bugs.webkit.org/show_bug.cgi?id=254545