### PR TITLE
Allow stepping through the Rust code

### DIFF
--- a/buildCore.js
+++ b/buildCore.js
@@ -5,11 +5,14 @@ let toolchain = "";
 let targetFolder = "debug";
 let cargoFlags = "";
 let rustFlags = "-C target-feature=+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext,+simd128";
+let wasmBindgenFlags = "";
 
 // Do an optimized build.
 if (process.argv.some((v) => v === "--release")) {
     targetFolder = "release";
     cargoFlags = "--release";
+} else {
+    wasmBindgenFlags += " --keep-debug";
 }
 
 // Do a fully optimized build ready for deployment.
@@ -66,7 +69,7 @@ execSync(
 );
 
 execSync(
-    `wasm-bindgen livesplit-core/target/wasm32-unknown-unknown/${targetFolder}/livesplit_core.wasm --out-dir src/livesplit-core`,
+    `wasm-bindgen ${wasmBindgenFlags} livesplit-core/target/wasm32-unknown-unknown/${targetFolder}/livesplit_core.wasm --out-dir src/livesplit-core`,
     {
         stdio: "inherit",
     },

--- a/test/rendering-test.js
+++ b/test/rendering-test.js
@@ -154,7 +154,7 @@ describe("Layout Rendering Tests", function () {
     testRendering("default", "default", "____________AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADgAAD_________");
     testRendering("default", "pmw3", "__wA___GX-AG3-gGUNgGQkAOXnAOW9gOX-APVtwOH_APX8AOX_APRnAOXVAOXJAeHvAeX_wf__AfAAAAAABgAAD_Pz9_____");
     testRendering("splits_two_rows", "celeste", "f8AAcAAHf8AA____d4AAcAAHf_gAcAAPd_AAYAAHf4AA____f4AAYAAH__AA____Z_gAYAAHf_8A9VVfb_wAcAAPf_AAYAAP");
-    testRendering("splits_with_labels", "celeste", "AABEAADPAADPAADPAADA____fAAH_wAP_wAP_wAPxgAA____QgAH34AP_4AH34APQYAA____0EAP_8AP38AP38APwAAAAAAA");
+    testRendering("splits_with_labels", "celeste", "AABEAADPAADPAADPAADA____fAAH_wAP_wAP_wAPxgAA____wgAH34AP_4AH34APQYAA____0EAP_8AP38AP38APQAAAAAAA");
     testRendering("title_centered_no_game_icon", "celeste", "________AAAAADQAAHQAAH4A______3_____AAAAAAAAAAAA____AAkAAL8DAP8DAP8DAP8D_________-n9AAAAAAAAAAAA");
     testRendering("title_centered_with_game_icon", "celeste", "________AAAAQBoAQBoAYB8A________9V-U4AAA4AAA4AAA4AAA4ASA4H_D4H_D4H_D4H_D_________9T84AAAAAAAAAAA");
     testRendering("title_left_no_attempt_count", "celeste", "________AAAA-AAA-AAA-AAA____________AAAAAAAAAAAA____rVKV_wAA_4AA_4AA_4AA________qf__AAAAAAAAAAAA");


### PR DESCRIPTION
This allows stepping through the Rust code. `wasm-bindgen` 0.2.89 just got released and it finally properly allows keeping the debug symbols that Rust creates around fully. Thankfully `webpack` does not pose a problem here and the debug symbols now properly work in Chrome, allowing us to step through the Rust code in the developer tools.

![image](https://github.com/LiveSplit/LiveSplitOne/assets/1451630/ce0f0e5e-be7c-4960-907c-27f8de340c53)
