### PR TITLE
Fix `wasm-opt` in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
       if: github.repository == 'LiveSplit/LiveSplitOne' && github.ref == 'refs/heads/master'
       run: |
         WASM_FILE=$(ls dist/*.wasm)
-        wasm-opt -O4 "$WASM_FILE" -o "$WASM_FILE"
+        wasm-opt --all-features -O4 "$WASM_FILE" -o "$WASM_FILE"
 
     - name: Add CNAME file
       if: github.repository == 'LiveSplit/LiveSplitOne' && github.ref == 'refs/heads/master'


### PR DESCRIPTION
Apparently it now requires you to specify which WebAssembly features to activate.