### PR TITLE
Use `performance.now()` for the frames instead

### DIFF
--- a/src/util/AutoRefresh.tsx
+++ b/src/util/AutoRefresh.tsx
@@ -31,7 +31,7 @@ export default class AutoRefresh extends React.Component<Props> {
     }
 
     private startAnimation() {
-        this.previousTime = Date.now();
+        this.previousTime = performance.now();
         this.animate();
     }
 
@@ -40,7 +40,7 @@ export default class AutoRefresh extends React.Component<Props> {
 
         assert(this.previousTime !== undefined, "Previous time must be defined");
 
-        const currentTime = Date.now();
+        const currentTime = performance.now();
         const elapsed = currentTime - this.previousTime;
 
         if (elapsed > this.fpsInterval) {


### PR DESCRIPTION
I'm not sure how `Date.now()` sneaked in there. Dates should only ever be used if the calendar is important, which is definitely not the case for managing the frame rate. Any NTP sync should haved messed with the frames before, at least to some slight degree.