### PR TITLE
Implement General Settings

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,6 +26,7 @@ try {
             hotkeys,
             layoutWidth,
             layoutHeight,
+            generalSettings,
         } = await LiveSplit.loadStoredData();
 
         function requestWakeLock() {
@@ -46,7 +47,19 @@ try {
 
         // The renderer requires the fonts to be loaded before it gets created
         // as otherwise information may be cached incorrectly.
-        await document.fonts.ready;
+        try {
+            const promises = [];
+            // TypeScript doesn't seem to know that the fonts are iterable.
+            for (const fontFace of (document.fonts as any as Iterable<FontFace>)) {
+                if (fontFace.family === 'timer' || fontFace.family === 'fira') {
+                    promises.push(fontFace.load());
+                }
+            }
+            await Promise.all(promises);
+        } catch {
+            // If somehow something goes wrong, that's kind of bad, but we
+            // should still have the fallback fonts that we can fall back to.
+        }
 
         ReactDOM.render(
             <div>
@@ -57,6 +70,7 @@ try {
                     splitsKey={splitsKey}
                     layoutWidth={layoutWidth}
                     layoutHeight={layoutHeight}
+                    generalSettings={generalSettings}
                 />
                 <ToastContainer
                     position={toast.POSITION.BOTTOM_RIGHT}

--- a/src/layout/Layout.tsx
+++ b/src/layout/Layout.tsx
@@ -5,6 +5,7 @@ import { WebRenderer } from "../livesplit-core/livesplit_core";
 import AutoRefresh from "../util/AutoRefresh";
 import { UrlCache } from "../util/UrlCache";
 import "../css/Layout.scss";
+import { GeneralSettings } from "../ui/SettingsEditor";
 
 export interface Props {
     getState: () => LayoutStateRef,
@@ -12,6 +13,7 @@ export interface Props {
     allowResize: boolean,
     width: number,
     height: number,
+    generalSettings: GeneralSettings,
     renderer: WebRenderer,
     onResize(width: number, height: number): void,
 }
@@ -27,7 +29,10 @@ export default class Layout extends React.Component<Props, unknown> {
 
     public render() {
         return (
-            <AutoRefresh update={() => this.refreshLayout()} >
+            <AutoRefresh
+                frameRate={this.props.generalSettings.frameRate}
+                update={() => this.refreshLayout()}
+            >
                 <div className="layout" style={{ width: this.props.width, height: this.props.height }}>
                     <div
                         style={{ width: "inherit", height: "inherit" }}

--- a/src/ui/LayoutEditor.tsx
+++ b/src/ui/LayoutEditor.tsx
@@ -5,6 +5,7 @@ import { SettingsComponent } from "./Settings";
 import { UrlCache } from "../util/UrlCache";
 import Layout from "../layout/Layout";
 import { WebRenderer } from "../livesplit-core/livesplit_core";
+import { GeneralSettings } from "./SettingsEditor";
 
 import "../css/LayoutEditor.scss";
 
@@ -15,6 +16,7 @@ export interface Props {
     layoutUrlCache: UrlCache,
     layoutWidth: number,
     layoutHeight: number,
+    generalSettings: GeneralSettings,
     isDesktop: boolean,
     timer: LiveSplit.SharedTimerRef,
     renderer: WebRenderer,
@@ -272,6 +274,7 @@ export class LayoutEditor extends React.Component<Props, State> {
                         allowResize={this.props.isDesktop}
                         width={this.props.layoutWidth}
                         height={this.props.layoutHeight}
+                        generalSettings={this.props.generalSettings}
                         renderer={this.props.renderer}
                         onResize={(width, height) => this.props.callbacks.onResize(width, height)}
                     />

--- a/src/ui/LayoutView.tsx
+++ b/src/ui/LayoutView.tsx
@@ -3,6 +3,7 @@ import { SharedTimer, Layout, LayoutStateRefMut } from "../livesplit-core";
 import { TimerView } from "./TimerView";
 import { UrlCache } from "../util/UrlCache";
 import { WebRenderer } from "../livesplit-core/livesplit_core";
+import { GeneralSettings } from "./SettingsEditor";
 
 export interface Props {
     isDesktop: boolean,
@@ -11,6 +12,7 @@ export interface Props {
     layoutUrlCache: UrlCache,
     layoutWidth: number,
     layoutHeight: number,
+    generalSettings: GeneralSettings,
     renderWithSidebar: boolean,
     sidebarOpen: boolean,
     timer: SharedTimer,
@@ -43,6 +45,7 @@ export class LayoutView extends React.Component<Props> {
             layoutUrlCache={this.props.layoutUrlCache}
             layoutWidth={this.props.layoutWidth}
             layoutHeight={this.props.layoutHeight}
+            generalSettings={this.props.generalSettings}
             isDesktop={this.props.isDesktop}
             renderWithSidebar={false}
             sidebarOpen={this.props.sidebarOpen}

--- a/src/ui/TimerView.tsx
+++ b/src/ui/TimerView.tsx
@@ -11,6 +11,7 @@ import AutoRefresh from "../util/AutoRefresh";
 import Layout from "../layout/Layout";
 import { UrlCache } from "../util/UrlCache";
 import { WebRenderer } from "../livesplit-core/livesplit_core";
+import { GeneralSettings } from "./SettingsEditor";
 
 import LiveSplitIcon from "../assets/icon.svg";
 
@@ -23,6 +24,7 @@ export interface Props {
     layoutUrlCache: UrlCache,
     layoutWidth: number,
     layoutHeight: number,
+    generalSettings: GeneralSettings,
     renderWithSidebar: boolean,
     sidebarOpen: boolean,
     timer: SharedTimer,
@@ -78,10 +80,14 @@ export class TimerView extends React.Component<Props, State> {
         >
             <div>
                 <div
-                    onClick={(_) => this.splitOrStart()}
+                    onClick={(_) => {
+                        if (this.props.generalSettings.showControlButtons) {
+                            this.splitOrStart();
+                        }
+                    }}
                     style={{
                         display: "inline-block",
-                        cursor: "pointer",
+                        cursor: this.props.generalSettings.showControlButtons ? "pointer" : undefined,
                     }}
                 >
                     <Layout
@@ -96,34 +102,37 @@ export class TimerView extends React.Component<Props, State> {
                         allowResize={this.props.isDesktop}
                         width={this.props.layoutWidth}
                         height={this.props.layoutHeight}
+                        generalSettings={this.props.generalSettings}
                         renderer={this.props.renderer}
                         onResize={(width, height) => this.props.callbacks.onResize(width, height)}
                     />
                 </div>
             </div>
-            <div className="buttons" style={{ width: this.props.layoutWidth }}>
-                <div className="small">
-                    <button aria-label="Undo Split" onClick={(_) => this.undoSplit()}>
-                        <i className="fa fa-arrow-up" aria-hidden="true" /></button>
-                    <button aria-label="Pause" onClick={(_) => this.togglePauseOrStart()}>
-                        <i className="fa fa-pause" aria-hidden="true" />
-                    </button>
-                </div>
-                <div className="small">
-                    <button aria-label="Skip Split" onClick={(_) => this.skipSplit()}>
-                        <i className="fa fa-arrow-down" aria-hidden="true" />
-                    </button>
-                    <button aria-label="Reset" onClick={(_) => this.reset()}>
-                        <i className="fa fa-times" aria-hidden="true" />
-                    </button>
-                </div>
-            </div>
+            {
+                this.props.generalSettings.showControlButtons ? <div className="buttons" style={{ width: this.props.layoutWidth }}>
+                    <div className="small">
+                        <button aria-label="Undo Split" onClick={(_) => this.undoSplit()}>
+                            <i className="fa fa-arrow-up" aria-hidden="true" /></button>
+                        <button aria-label="Pause" onClick={(_) => this.togglePauseOrStart()}>
+                            <i className="fa fa-pause" aria-hidden="true" />
+                        </button>
+                    </div>
+                    <div className="small">
+                        <button aria-label="Skip Split" onClick={(_) => this.skipSplit()}>
+                            <i className="fa fa-arrow-down" aria-hidden="true" />
+                        </button>
+                        <button aria-label="Reset" onClick={(_) => this.reset()}>
+                            <i className="fa fa-times" aria-hidden="true" />
+                        </button>
+                    </div>
+                </div> : null
+            }
         </DragUpload>;
     }
 
     private renderSidebarContent() {
         return (
-            <AutoRefresh update={() => this.updateSidebar()}>
+            <AutoRefresh frameRate={10} update={() => this.updateSidebar()}>
                 <div className="sidebar-buttons">
                     <div className="livesplit-title">
                         <span className="livesplit-icon">

--- a/src/util/AutoRefresh.tsx
+++ b/src/util/AutoRefresh.tsx
@@ -1,20 +1,14 @@
 import * as React from "react";
-import { assert } from "./OptionUtil";
+import { FRAME_RATE_AUTOMATIC, FrameRateSetting, batteryAwareFrameRate } from "./FrameRate";
 
 export interface Props {
+    frameRate: FrameRateSetting,
     update(): void,
 }
 
 export default class AutoRefresh extends React.Component<Props> {
-    private readonly fpsInterval = 1000 / 30;
-    private reqId: number | null;
-    private previousTime: number | undefined;
-
-    constructor(props: Props) {
-        super(props);
-
-        this.reqId = null;
-    }
+    private reqId: number | null = null;
+    private previousTime: number = 0;
 
     public componentWillMount() {
         this.startAnimation();
@@ -31,21 +25,30 @@ export default class AutoRefresh extends React.Component<Props> {
     }
 
     private startAnimation() {
-        this.previousTime = performance.now();
+        this.previousTime = 0;
         this.animate();
     }
 
     private animate() {
         this.reqId = requestAnimationFrame(() => this.animate());
 
-        assert(this.previousTime !== undefined, "Previous time must be defined");
-
-        const currentTime = performance.now();
-        const elapsed = currentTime - this.previousTime;
-
-        if (elapsed > this.fpsInterval) {
-            this.previousTime = currentTime - (elapsed % this.fpsInterval);
-            this.props.update();
+        let frameRate = this.props.frameRate;
+        if (frameRate === FRAME_RATE_AUTOMATIC) {
+            frameRate = batteryAwareFrameRate;
         }
+
+        if (typeof frameRate === "number") {
+            const currentTime = performance.now();
+            const elapsed = currentTime - this.previousTime;
+
+            const refreshInterval = 1000 / frameRate;
+
+            if (elapsed < refreshInterval) {
+                return;
+            }
+            this.previousTime = currentTime - (elapsed % refreshInterval);
+        }
+
+        this.props.update();
     }
 }

--- a/src/util/FrameRate.ts
+++ b/src/util/FrameRate.ts
@@ -1,0 +1,31 @@
+export const FRAME_RATE_MATCH_SCREEN = "Match Screen";
+export const FRAME_RATE_AUTOMATIC = "Battery Aware";
+
+const LOW_POWER_REFRESH_RATE = 30;
+
+export type FrameRateSetting = FrameRate | typeof FRAME_RATE_AUTOMATIC;
+export type FrameRate = number | typeof FRAME_RATE_MATCH_SCREEN;
+
+(async () => {
+    try {
+        const batteryApi = await (navigator as any).getBattery();
+        batteryApi.onchargingchange = () => {
+            batteryAwareFrameRate = batteryApi.charging === true
+                ? FRAME_RATE_MATCH_SCREEN
+                : LOW_POWER_REFRESH_RATE;
+        };
+    } catch {
+        // The battery API is not supported by every browser.
+    }
+})();
+
+// In case the battery API is not available, we use try to use the name
+// of the platform to determine the frame rate whether it's usually a
+// battery-powered device or not.
+export let batteryAwareFrameRate: FrameRate = FRAME_RATE_MATCH_SCREEN;
+switch (navigator.platform) {
+    case "iPhone":
+    case "iPad":
+    case "Android":
+        batteryAwareFrameRate = LOW_POWER_REFRESH_RATE;
+}


### PR DESCRIPTION
This adds the following two settings:

1. Show Control Buttons: Determines whether to show buttons beneath the timer that allow controlling it. When disabled, you have to use the hotkeys instead.
2. Frame Rate: Determines the frame rate at which to display the timer. "Battery Aware" tries determining the type of device and charging status to select a good frame rate. "Match Screen" makes the timer match the screen's refresh rate.

Additionally this fixes a bug where the fonts were not properly loaded by the time the web renderer gets created, which then cached information about the fallback fonts instead of the actual fonts.