### PR TITLE
Switch `wasm-bindgen` bindings to `Symbol.dispose`

### DIFF
--- a/src/storage/index.tsx
+++ b/src/storage/index.tsx
@@ -36,12 +36,12 @@ function getSplitsInfo(run: RunRef): SplitsInfo {
 }
 
 function parseSplitsAndGetInfo(splits: Uint8Array): Option<SplitsInfo> {
-    return Run.parseArray(splits, "").with((r) => {
-        if (r.parsedSuccessfully()) {
-            return r.unwrap();
-        }
+    using parseRunResult = Run.parseArray(splits, "");
+    if (!parseRunResult.parsedSuccessfully()) {
         return undefined;
-    })?.with(getSplitsInfo);
+    }
+    using run = parseRunResult.unwrap();
+    return getSplitsInfo(run);
 }
 
 function getDb(): Promise<IDBPDatabase<unknown>> {
@@ -118,7 +118,7 @@ export async function storeRunAndDispose(run: Run, key: number | undefined) {
     try {
         await storeRunWithoutDisposing(run, key);
     } finally {
-        run.dispose();
+        run[Symbol.dispose]();
     }
 }
 

--- a/src/ui/SplitsSelection.tsx
+++ b/src/ui/SplitsSelection.tsx
@@ -209,13 +209,13 @@ export class SplitsSelection extends React.Component<Props, State> {
             throw Error("The splits key is invalid.");
         }
 
-        return Run.parseArray(new Uint8Array(splitsData), "").with((result) => {
-            if (result.parsedSuccessfully()) {
-                return result.unwrap();
-            } else {
-                throw Error("Couldn't parse the splits.");
-            }
-        });
+        using result = Run.parseArray(new Uint8Array(splitsData), "");
+
+        if (result.parsedSuccessfully()) {
+            return result.unwrap();
+        } else {
+            throw Error("Couldn't parse the splits.");
+        }
     }
 
     private async openSplits(key: number) {
@@ -226,13 +226,11 @@ export class SplitsSelection extends React.Component<Props, State> {
             return;
         }
 
-        const run = await this.getRunFromKey(key);
-        run.with((run) => {
-            maybeDisposeAndThen(
-                this.props.timer.writeWith((timer) => timer.setRun(run)),
-                () => toast.error("The loaded splits are invalid."),
-            );
-        });
+        using run = await this.getRunFromKey(key);
+        maybeDisposeAndThen(
+            this.props.timer.writeWith((timer) => timer.setRun(run)),
+            () => toast.error("The loaded splits are invalid."),
+        );
         this.props.callbacks.setSplitsKey(key);
     }
 
@@ -312,7 +310,7 @@ export class SplitsSelection extends React.Component<Props, State> {
                 throw Error("Couldn't parse the splits.");
             }
         } finally {
-            result.dispose();
+            result[Symbol.dispose]();
         }
     }
 
@@ -394,7 +392,7 @@ export class SplitsSelection extends React.Component<Props, State> {
             await storeRunWithoutDisposing(run, undefined);
             await this.refreshDb();
         } finally {
-            run.dispose();
+            run[Symbol.dispose]();
         }
     }
 }

--- a/src/ui/TimerView.tsx
+++ b/src/ui/TimerView.tsx
@@ -147,17 +147,15 @@ export class TimerView extends React.Component<Props, State> {
                                     if ((t.currentPhase() as LiveSplit.TimerPhase) === LiveSplit.TimerPhase.NotRunning) {
                                         t.start();
                                         t.pauseGameTime();
-                                        const gameTime = TimeSpan.parse(this.state.manualGameTime)
+                                        using gameTime = TimeSpan.parse(this.state.manualGameTime)
                                             ?? expect(TimeSpan.parse("0"), "Failed to parse TimeSpan");
-                                        gameTime.with((gameTime) => t.setGameTime(gameTime));
+                                        t.setGameTime(gameTime);
                                         this.setState({ manualGameTime: "" });
                                     } else {
-                                        const gameTime = TimeSpan.parse(this.state.manualGameTime);
+                                        using gameTime = TimeSpan.parse(this.state.manualGameTime);
                                         if (gameTime !== null) {
-                                            gameTime.with((gameTime) => {
-                                                t.setGameTime(gameTime);
-                                                t.split();
-                                            });
+                                            t.setGameTime(gameTime);
+                                            t.split();
                                             this.setState({ manualGameTime: "" });
                                         }
                                     }
@@ -394,20 +392,16 @@ export class TimerView extends React.Component<Props, State> {
     }
 
     private setGameTime(gameTime: string) {
-        const time = TimeSpan.parse(gameTime);
+        using time = TimeSpan.parse(gameTime);
         if (time !== null) {
-            time.with((time) => {
-                this.writeWith((t) => t.setGameTime(time));
-            });
+            this.writeWith((t) => t.setGameTime(time));
         }
     }
 
     private setLoadingTimes(loadingTimes: string) {
-        const time = TimeSpan.parse(loadingTimes);
+        using time = TimeSpan.parse(loadingTimes);
         if (time !== null) {
-            time.with((time) => {
-                this.writeWith((t) => t.setLoadingTimes(time));
-            });
+            this.writeWith((t) => t.setLoadingTimes(time));
         }
     }
 

--- a/src/util/OptionUtil.ts
+++ b/src/util/OptionUtil.ts
@@ -10,7 +10,7 @@ export function expect<T>(obj: Option<T>, message: string): T {
 }
 
 interface Disposable {
-    dispose(): void,
+    [Symbol.dispose](): void,
 }
 
 export function panic(message: string): never {
@@ -28,14 +28,14 @@ export function assert(condition: boolean, message: string): asserts condition {
 
 export function assertNull<T>(obj: Option<T | Disposable>, message: string): asserts obj is null | undefined {
     if (obj != null) {
-        (obj as any).dispose?.();
+        (obj as any)[Symbol.dispose]?.();
         panic(message);
     }
 }
 
 export function maybeDisposeAndThen(obj: Option<Disposable>, f: () => void) {
     if (obj != null) {
-        obj.dispose();
+        obj[Symbol.dispose]();
         f();
     }
 }

--- a/src/util/SplitsIO.ts
+++ b/src/util/SplitsIO.ts
@@ -90,11 +90,10 @@ export async function downloadById(id: string): Promise<Run> {
         DownloadError.InvalidBuffer,
     );
 
-    return Run.parseArray(new Uint8Array(data), "").with((result) => {
-        if (result.parsedSuccessfully()) {
-            return result.unwrap();
-        } else {
-            throw DownloadError.FailedParsing;
-        }
-    });
+    using result = Run.parseArray(new Uint8Array(data), "");
+    if (result.parsedSuccessfully()) {
+        return result.unwrap();
+    } else {
+        throw DownloadError.FailedParsing;
+    }
 }


### PR DESCRIPTION
There is a [JavaScript
proposal](https://github.com/tc39/proposal-explicit-resource-management) for using `Symbol.dispose` as a way to automatically clean up resources. You do that by declaring variables like so:
```js
using resource = new Resource();
```
The variable `resource` will be automatically disposed when it goes out of scope. We used to have our own `dispose` method and `with` helper method that allows scoped access to the resource, before it gets cleaned up at the end. TypeScript already fully implements and polyfills support for it, so we can already fully switch over to it.