### PR TITLE
Fix Symbol.dispose polyfill for old browsers

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,23 @@
+// FIXME: Remove the polyfill later.
+
+if (typeof Symbol.dispose !== "symbol") {
+    Object.defineProperty(Symbol, "dispose", {
+        configurable: false,
+        enumerable: false,
+        writable: false,
+        value: Symbol.for("dispose")
+    });
+}
+
+if (typeof Symbol.asyncDispose !== "symbol") {
+    Object.defineProperty(Symbol, "asyncDispose", {
+        configurable: false,
+        enumerable: false,
+        writable: false,
+        value: Symbol.for("asyncDispose")
+    });
+}
+
 if (process.env.NODE_ENV === "production" && "serviceWorker" in navigator) {
     navigator.serviceWorker.register("/service-worker.js");
 }


### PR DESCRIPTION
While TypeScript can polyfill almost everything regarding the `Symbol.dispose` functionality, it does not actually polyfill the symbol itself for some reason?!