### PR TITLE
Allow toggling speedrun.com, splits.io integration

### DIFF
--- a/src/storage/index.tsx
+++ b/src/storage/index.tsx
@@ -252,5 +252,7 @@ export async function loadGeneralSettings(): Promise<GeneralSettings> {
         frameRate: generalSettings.frameRate ?? FRAME_RATE_AUTOMATIC,
         showControlButtons: generalSettings.showControlButtons ?? true,
         showManualGameTime: generalSettings.showManualGameTime ?? false,
+        speedrunComIntegration: generalSettings.speedrunComIntegration ?? true,
+        splitsIoIntegration: generalSettings.splitsIoIntegration ?? true,
     };
 }

--- a/src/ui/LiveSplit.tsx
+++ b/src/ui/LiveSplit.tsx
@@ -253,6 +253,7 @@ export class LiveSplit extends React.Component<Props, State> {
                 editor={this.state.menu.editor}
                 callbacks={this}
                 runEditorUrlCache={this.state.runEditorUrlCache}
+                generalSettings={this.state.generalSettings}
             />;
         } else if (this.state.menu.kind === MenuKind.LayoutEditor) {
             return <LayoutEditorComponent
@@ -279,6 +280,7 @@ export class LiveSplit extends React.Component<Props, State> {
             return <About callbacks={this} />;
         } else if (this.state.menu.kind === MenuKind.Splits) {
             return <SplitsSelection
+                generalSettings={this.state.generalSettings}
                 timer={this.state.timer}
                 openedSplitsKey={this.state.openedSplitsKey}
                 callbacks={this}

--- a/src/ui/SettingsEditor.tsx
+++ b/src/ui/SettingsEditor.tsx
@@ -12,6 +12,8 @@ export interface GeneralSettings {
     frameRate: FrameRateSetting,
     showControlButtons: boolean,
     showManualGameTime: boolean,
+    speedrunComIntegration: boolean,
+    splitsIoIntegration: boolean,
 }
 
 export interface Props {
@@ -126,6 +128,50 @@ export class SettingsEditor extends React.Component<Props, State> {
                                         generalSettings: {
                                             ...this.state.generalSettings,
                                             showManualGameTime: value.Bool,
+                                        },
+                                    });
+                                }
+                                break;
+                        }
+                    }}
+                />
+                <h2>Network</h2>
+                <SettingsComponent
+                    context="settings-editor-general"
+                    factory={new JsonSettingValueFactory()}
+                    state={{
+                        fields: [
+                            {
+                                text: "Speedrun.com Integration",
+                                tooltip: "Queries the list of games, categories, and the leaderboards from speedrun.com.",
+                                value: { Bool: this.state.generalSettings.speedrunComIntegration },
+                            },
+                            {
+                                text: "Splits.io Integration",
+                                tooltip: "Allows you to upload splits to and download splits from splits.io.",
+                                value: { Bool: this.state.generalSettings.splitsIoIntegration },
+                            },
+                        ],
+                    }}
+                    editorUrlCache={this.props.urlCache}
+                    setValue={(index, value) => {
+                        switch (index) {
+                            case 0:
+                                if ("Bool" in value) {
+                                    this.setState({
+                                        generalSettings: {
+                                            ...this.state.generalSettings,
+                                            speedrunComIntegration: value.Bool,
+                                        },
+                                    });
+                                }
+                                break;
+                            case 1:
+                                if ("Bool" in value) {
+                                    this.setState({
+                                        generalSettings: {
+                                            ...this.state.generalSettings,
+                                            splitsIoIntegration: value.Bool,
                                         },
                                     });
                                 }

--- a/src/ui/SplitsSelection.tsx
+++ b/src/ui/SplitsSelection.tsx
@@ -9,10 +9,11 @@ import { toast } from "react-toastify";
 import { openFileAsArrayBuffer, exportFile, convertFileToArrayBuffer } from "../util/FileUtil";
 import { Option, maybeDisposeAndThen } from "../util/OptionUtil";
 import * as Storage from "../storage";
-
-import "../css/SplitsSelection.scss";
 import DragUpload from "./DragUpload";
 import { ContextMenuTrigger, ContextMenu, MenuItem } from "react-contextmenu";
+import { GeneralSettings } from "./SettingsEditor";
+
+import "../css/SplitsSelection.scss";
 
 export interface EditingInfo {
     splitsKey?: number,
@@ -23,6 +24,7 @@ export interface Props {
     timer: SharedTimerRef,
     openedSplitsKey?: number,
     callbacks: Callbacks,
+    generalSettings: GeneralSettings,
 }
 
 interface State {
@@ -70,9 +72,11 @@ export class SplitsSelection extends React.Component<Props, State> {
                         <button onClick={() => this.importSplits()}>
                             <i className="fa fa-download" aria-hidden="true" /> Import
                         </button>
-                        <button onClick={() => this.importSplitsFromSplitsIO()}>
-                            <i className="fa fa-download" aria-hidden="true" /> From Splits.io
-                        </button>
+                        {
+                            this.props.generalSettings.splitsIoIntegration && <button onClick={() => this.importSplitsFromSplitsIO()}>
+                                <i className="fa fa-download" aria-hidden="true" /> From Splits.io
+                            </button>
+                        }
                     </div>
                     {
                         this.state.splitsInfos?.length > 0 &&
@@ -139,9 +143,11 @@ export class SplitsSelection extends React.Component<Props, State> {
                                     <MenuItem onClick={(_) => this.exportSplits(key, info)}>
                                         Export to File
                                     </MenuItem>
-                                    <MenuItem onClick={(_) => this.uploadSplitsToSplitsIO(key)}>
-                                        Upload to Splits.io
-                                    </MenuItem>
+                                    {
+                                        this.props.generalSettings.splitsIoIntegration && <MenuItem onClick={(_) => this.uploadSplitsToSplitsIO(key)}>
+                                            Upload to Splits.io
+                                        </MenuItem>
+                                    }
                                 </ContextMenu>
                             </>
                     }
@@ -192,9 +198,11 @@ export class SplitsSelection extends React.Component<Props, State> {
                 <button onClick={(_) => this.exportTimerSplits()}>
                     <i className="fa fa-upload" aria-hidden="true" /> Export
                 </button>
-                <button onClick={(_) => this.uploadTimerToSplitsIO()}>
-                    <i className="fa fa-upload" aria-hidden="true" /> Upload to Splits.io
-                </button>
+                {
+                    this.props.generalSettings.splitsIoIntegration && <button onClick={(_) => this.uploadTimerToSplitsIO()}>
+                        <i className="fa fa-upload" aria-hidden="true" /> Upload to Splits.io
+                    </button>
+                }
                 <hr />
                 <button onClick={(_) => this.props.callbacks.openTimerView()}>
                     <i className="fa fa-caret-left" aria-hidden="true" /> Back

--- a/src/ui/TimerView.tsx
+++ b/src/ui/TimerView.tsx
@@ -111,7 +111,7 @@ export class TimerView extends React.Component<Props, State> {
                 </div>
             </div>
             {
-                this.props.generalSettings.showControlButtons ? <div className="buttons" style={{ width: this.props.layoutWidth }}>
+                this.props.generalSettings.showControlButtons && <div className="buttons" style={{ width: this.props.layoutWidth }}>
                     <div className="small">
                         <button aria-label="Undo Split" onClick={(_) => this.undoSplit()}>
                             <i className="fa fa-arrow-up" aria-hidden="true" /></button>
@@ -127,10 +127,10 @@ export class TimerView extends React.Component<Props, State> {
                             <i className="fa fa-times" aria-hidden="true" />
                         </button>
                     </div>
-                </div> : null
+                </div>
             }
             {
-                this.props.generalSettings.showManualGameTime ? <div className="buttons" style={{ width: this.props.layoutWidth }}>
+                this.props.generalSettings.showManualGameTime && <div className="buttons" style={{ width: this.props.layoutWidth }}>
                     <input
                         type="text"
                         className="manual-game-time"
@@ -163,7 +163,7 @@ export class TimerView extends React.Component<Props, State> {
                             }
                         }}
                     />
-                </div> : null
+                </div>
             }
         </DragUpload>;
     }


### PR DESCRIPTION
This adds settings for turning off the integration with speedrun.com and splits.io. This is useful for people who don't want to use these features and want to avoid the extra network requests. While splits.io doesn't do any automatic network requests in the background, it still adds buttons to the UI that someone may not want to see. It's also more consistent to have a toggle for both.