### PR TITLE
Prompt when there is an update

### DIFF
--- a/src/ui/LiveSplit.tsx
+++ b/src/ui/LiveSplit.tsx
@@ -190,10 +190,9 @@ export class LiveSplit extends React.Component<Props, State> {
         };
 
         this.mediaQueryChanged = this.mediaQueryChanged.bind(this);
-        this.notifyAboutUpdate = this.notifyAboutUpdate.bind(this);
     }
 
-    private notifyAboutUpdate()
+    private notifyAboutUpdate(this: void)
     {
         toast.warn(
             'A new version of LiveSplit One is available! Click here to reload.',

--- a/src/ui/LiveSplit.tsx
+++ b/src/ui/LiveSplit.tsx
@@ -190,6 +190,18 @@ export class LiveSplit extends React.Component<Props, State> {
         };
 
         this.mediaQueryChanged = this.mediaQueryChanged.bind(this);
+        this.notifyAboutUpdate = this.notifyAboutUpdate.bind(this);
+    }
+
+    private notifyAboutUpdate()
+    {
+        toast.warn(
+            'A new version of LiveSplit One is available! Click here to reload.',
+            {
+              closeOnClick: true,
+              onClick: () => window.location.reload(),
+            },
+        );
     }
 
     public componentDidMount() {
@@ -218,6 +230,11 @@ export class LiveSplit extends React.Component<Props, State> {
         }
 
         this.handleAutomaticResize();
+
+        const { serviceWorker } = navigator;
+        if (serviceWorker) {
+          serviceWorker.addEventListener('controllerchange', this.notifyAboutUpdate);
+        }
     }
 
     public componentDidUpdate() {
@@ -245,6 +262,11 @@ export class LiveSplit extends React.Component<Props, State> {
         // This is bound in the constructor
         // eslint-disable-next-line @typescript-eslint/unbound-method
         this.isDesktopQuery.removeEventListener("change", this.mediaQueryChanged);
+
+        const { serviceWorker } = navigator;
+        if (serviceWorker) {
+            serviceWorker.removeEventListener('controllerchange', this.notifyAboutUpdate);
+        }
     }
 
     public render() {


### PR DESCRIPTION
https://github.com/LiveSplit/LiveSplitOne/issues/888#issuecomment-2132244331

When opening LiveSplit One, the service worker downloads the latest files in the background, which usually takes a few seconds. After the files are downloaded, if it detects a change, it will now show a popup message in the bottom-right corner that can be clicked to auto-refresh the page. (The message will automatically disappear after 5 seconds to avoid being too intrusive.)

https://github.com/LiveSplit/LiveSplitOne/assets/8262173/cad287d6-1ed7-48a0-9318-b86211bb9b76

