### PR TITLE
Add a changelog and improve contributors section

### DIFF
--- a/src/css/About.scss
+++ b/src/css/About.scss
@@ -1,7 +1,6 @@
 @import 'mobile';
 @import 'variables';
 
-$text-width: 400px;
 $icon-size: 40px;
 $title-font-size: 40px;
 $build-version-font-size: 12px;
@@ -37,33 +36,53 @@ $link-color: #56b0ff;
       font-size: $build-version-font-size;
     }
 
-    .contributors-header {
-      margin-bottom: 0;
-    }
-
-    .contributor {
-      margin-block-start: 0.5em;
-      margin-block-end: 0.5em;
-
-      &:last-child {
-        margin-block-end: 0;
-      }
+    h2 {
+      margin-bottom: $ui-large-margin;
     }
 
     a {
       color: $link-color;
     }
 
-    p {
-      max-width: $text-width;
+    .changelog {
+      margin-left: $ui-large-margin;
 
-      @include mobile {
-        max-width: 100%;
+      >div {
+        margin: $ui-large-margin 0 $ui-large-margin $ui-large-margin;
+      }
+    }
+
+    .contributors {
+      margin: 0 auto;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 14px;
+      justify-content: space-evenly;
+      align-items: end;
+      font-size: 14px;
+
+      a {
+        display: flex;
+        align-items: center;
+        flex-direction: column;
+        gap: 4px;
+
+        img {
+          width: $contributor-avatar-size;
+          height: $contributor-avatar-size;
+          border-radius: 50%;
+        }
       }
     }
 
     @include mobile {
       box-sizing: border-box;
     }
+  }
+
+  max-width: 700px;
+
+  @include mobile {
+    max-width: 100%;
   }
 }

--- a/src/css/variables.scss
+++ b/src/css/variables.scss
@@ -7,6 +7,8 @@ $main-content-margin: 24px;
 $settings-table-width: 500px;
 $settings-row-height: 19px;
 
+$contributor-avatar-size: 42px;
+
 $border-color: #404040;
 
 $button-active-color: linear-gradient(hsl(0, 0%, 13%) 0%, hsl(0, 0%, 23%) 100%);
@@ -35,4 +37,5 @@ $selected-row-hover-color: linear-gradient(hsl(220, 90%, 70%) 0%, hsl(220, 69%, 
   buttonHeight: $button-height;
   largeMargin: $ui-large-margin;
   manualGameTimeHeight: $manual-game-time-height;
+  contributorAvatarSize: $contributor-avatar-size;
 }

--- a/src/type-definitions/webpack-globals.d.ts
+++ b/src/type-definitions/webpack-globals.d.ts
@@ -1,3 +1,15 @@
 declare const BUILD_DATE: string;
 declare const COMMIT_HASH: string;
-declare const CONTRIBUTORS_LIST: string[];
+declare const CONTRIBUTORS_LIST: Contributor[];
+declare const CHANGELOG: ChangelogEntry[];
+
+declare interface Contributor {
+    id: string,
+    name: string,
+}
+
+declare interface ChangelogEntry {
+    id: string,
+    message: string,
+    date: string,
+}

--- a/src/ui/About.tsx
+++ b/src/ui/About.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 
 import LiveSplitIcon from "../assets/icon.svg";
+import { renderMarkdown } from "../util/Markdown";
+import variables from "../css/variables.scss";
 
 import "../css/About.scss";
 
@@ -13,6 +15,13 @@ interface Callbacks {
     openTimerView(): void,
 }
 
+const changelogRenderSettings = {
+    softBreak: false,
+    escapeHtml: false,
+};
+
+const contributorAvatarSize = parseFloat(variables.contributorAvatarSize);
+
 export class About extends React.Component<Props> {
     public render() {
         const renderedView = this.renderView();
@@ -21,6 +30,8 @@ export class About extends React.Component<Props> {
     }
 
     private renderView() {
+        const idealAvatarResolution = Math.round(devicePixelRatio * contributorAvatarSize);
+
         return (
             <div className="about">
                 <div className="about-inner-container">
@@ -42,14 +53,35 @@ export class About extends React.Component<Props> {
                             View Source Code on GitHub
                         </a>
                     </p>
-                    <h2 className="contributors-header">Contributors</h2>
-                    {
-                        CONTRIBUTORS_LIST.map((contributor) => (
-                            <p className="contributor">
-                                <a href={`https://github.com/${contributor}`} target="_blank">{contributor}</a>
-                            </p>
-                        ))
-                    }
+                    <h2>Recent Changes</h2>
+                    <div className="changelog">
+                        {
+                            CHANGELOG.map((change) => (
+                                <>
+                                    <a href={`https://github.com/LiveSplit/LiveSplitOne/commit/${change.id}`} target="_blank">
+                                        {change.date}
+                                    </a>
+                                    <div>
+                                        {renderMarkdown(change.message, changelogRenderSettings)}
+                                    </div>
+                                </>
+                            ))
+                        }
+                    </div>
+                    <h2>Contributors</h2>
+                    <div className="contributors">
+                        {
+                            CONTRIBUTORS_LIST.map((contributor) => (
+                                <a href={`https://github.com/${contributor.name}`} target="_blank">
+                                    <img
+                                        src={`https://avatars.githubusercontent.com/u/${contributor.id}?s=${idealAvatarResolution}&v=4`}
+                                        onError={(e) => (e.target as any).remove()}
+                                    />
+                                    {contributor.name}
+                                </a>
+                            ))
+                        }
+                    </div>
                 </div>
             </div>
         );

--- a/src/util/Markdown.tsx
+++ b/src/util/Markdown.tsx
@@ -22,13 +22,16 @@ export function replaceFlag(countryCode: string): JSX.Element {
     return <img className="flag" src={url} alt={countryCode} />;
 }
 
-export function renderMarkdown(markdown: string): JSX.Element {
+export function renderMarkdown(markdown: string, options: {
+    softBreak?: boolean,
+    escapeHtml?: boolean,
+} = {}): JSX.Element {
     const markdownWithEmotes = replaceTwitchEmotes(markdown);
     const parsed = new CommonMarkParser().parse(markdownWithEmotes);
     const renderedMarkdown = new CommonMarkRenderer({
-        escapeHtml: true,
+        escapeHtml: options.escapeHtml ?? true,
         linkTarget: "_blank",
-        softBreak: "br",
+        softBreak: options.softBreak === false ? undefined : "br",
     }).render(parsed);
 
     return (


### PR DESCRIPTION
This improves the contributors section in the About page. It now uses flexbox to dynamically place the contributors. Additionally their avatar is now being shown.

Also the ten most recent changes are now being shown in the About page. The information is extracted from the git history. The idea is to mark commit messages with a special changelog section at the end that's specifically meant to be shown as a user facing change. It can be arbitrary markdown and looks like this (which is also the first one):

Changelog: The About page now shows the most recent changes. The contributors section has also been improved. It now shows the avatar of each contributor.