### PR TITLE
Implement Save On Reset

### DIFF
--- a/src/storage/index.tsx
+++ b/src/storage/index.tsx
@@ -252,6 +252,7 @@ export async function loadGeneralSettings(): Promise<GeneralSettings> {
         frameRate: generalSettings.frameRate ?? FRAME_RATE_AUTOMATIC,
         showControlButtons: generalSettings.showControlButtons ?? true,
         showManualGameTime: generalSettings.showManualGameTime ?? false,
+        saveOnReset: generalSettings.saveOnReset ?? false,
         speedrunComIntegration: generalSettings.speedrunComIntegration ?? true,
         splitsIoIntegration: generalSettings.splitsIoIntegration ?? true,
         serverUrl: generalSettings.serverUrl,

--- a/src/ui/LSOEventSink.ts
+++ b/src/ui/LSOEventSink.ts
@@ -10,6 +10,7 @@ export class LSOEventSink {
         private currentTimingMethodChanged: () => void,
         private currentPhaseChanged: () => void,
         private currentSplitChanged: () => void,
+        private onReset: () => void,
     ) {
         this.eventSink = new EventSink(new WebEventSink(this).intoGeneric());
     }
@@ -54,6 +55,7 @@ export class LSOEventSink {
 
         this.currentPhaseChanged();
         this.currentSplitChanged();
+        this.onReset();
     }
 
     public undoSplit(): void {

--- a/src/ui/LiveSplit.tsx
+++ b/src/ui/LiveSplit.tsx
@@ -129,6 +129,7 @@ export class LiveSplit extends React.Component<Props, State> {
             () => this.currentTimingMethodChanged(),
             () => this.currentPhaseChanged(),
             () => this.currentSplitChanged(),
+            () => this.onReset(),
         );
 
         const hotkeys = props.hotkeys;
@@ -443,6 +444,7 @@ export class LiveSplit extends React.Component<Props, State> {
         try {
             const layout = this.state.layout.settingsAsJson();
             await Storage.storeLayout(layout);
+            toast.info("Layout saved successfully.");
         } catch (_) {
             toast.error("Failed to save the layout.");
         }
@@ -715,6 +717,24 @@ export class LiveSplit extends React.Component<Props, State> {
         e.preventDefault();
     }
 
+    async saveSplits() {
+        try {
+            const openedSplitsKey = await Storage.storeSplits(
+                (callback) => {
+                    callback(this.state.eventSink.getRun(), this.state.eventSink.saveAsLssBytes());
+                    this.state.eventSink.markAsUnmodified();
+                },
+                this.state.openedSplitsKey,
+            );
+            if (this.state.openedSplitsKey !== openedSplitsKey) {
+                this.setSplitsKey(openedSplitsKey);
+            }
+            toast.info("Splits saved successfully.");
+        } catch (_) {
+            toast.error("Failed to save the splits.");
+        }
+    }
+
     onServerConnectionOpened(serverConnection: LiveSplitServer): void {
         this.setState({ serverConnection });
     }
@@ -752,6 +772,12 @@ export class LiveSplit extends React.Component<Props, State> {
             this.setState({
                 currentSplitIndex: this.state.eventSink.currentSplitIndex(),
             });
+        }
+    }
+
+    onReset(): void {
+        if (this.state.generalSettings.saveOnReset) {
+            this.saveSplits();
         }
     }
 }

--- a/src/ui/SettingsEditor.tsx
+++ b/src/ui/SettingsEditor.tsx
@@ -15,7 +15,7 @@ export interface GeneralSettings {
     frameRate: FrameRateSetting,
     showControlButtons: boolean,
     showManualGameTime: boolean,
-    // saveOnReset: boolean,
+    saveOnReset: boolean,
     speedrunComIntegration: boolean,
     splitsIoIntegration: boolean,
     serverUrl: string | undefined,
@@ -103,6 +103,13 @@ export class SettingsEditor extends React.Component<Props, State> {
                                 tooltip: "Shows a text box beneath the timer that allows you to manually input the game time. You start the timer and do splits by pressing the Enter key in the text box. Make sure to compare against \"Game Time\".",
                                 value: { Bool: this.state.generalSettings.showManualGameTime },
                             },
+                            {
+                                text: "Save On Reset",
+                                tooltip: "Determines whether to automatically save the splits when resetting the timer.",
+                                value: {
+                                    Bool: this.state.generalSettings.saveOnReset,
+                                },
+                            },
                         ],
                     }}
                     editorUrlCache={this.props.urlCache}
@@ -138,6 +145,16 @@ export class SettingsEditor extends React.Component<Props, State> {
                                         generalSettings: {
                                             ...this.state.generalSettings,
                                             showManualGameTime: value.Bool,
+                                        },
+                                    });
+                                }
+                                break;
+                            case 3:
+                                if ("Bool" in value) {
+                                    this.setState({
+                                        generalSettings: {
+                                            ...this.state.generalSettings,
+                                            saveOnReset: value.Bool,
                                         },
                                     });
                                 }

--- a/src/ui/SplitsSelection.tsx
+++ b/src/ui/SplitsSelection.tsx
@@ -8,7 +8,6 @@ import * as SplitsIO from "../util/SplitsIO";
 import { toast } from "react-toastify";
 import { openFileAsArrayBuffer, exportFile, convertFileToArrayBuffer } from "../util/FileUtil";
 import { Option, maybeDisposeAndThen } from "../util/OptionUtil";
-import * as Storage from "../storage";
 import DragUpload from "./DragUpload";
 import { ContextMenuTrigger, ContextMenu, MenuItem } from "react-contextmenu";
 import { GeneralSettings } from "./SettingsEditor";
@@ -37,6 +36,7 @@ interface Callbacks {
     setSplitsKey(newKey?: number): void,
     openTimerView(): void,
     renderViewWithSidebar(renderedView: JSX.Element, sidebarContent: JSX.Element): JSX.Element,
+    saveSplits(): Promise<void>,
 }
 
 export class SplitsSelection extends React.Component<Props, State> {
@@ -321,21 +321,8 @@ export class SplitsSelection extends React.Component<Props, State> {
     }
 
     private async saveSplits() {
-        try {
-            const openedSplitsKey = await Storage.storeSplits(
-                (callback) => {
-                    callback(this.props.eventSink.getRun(), this.props.eventSink.saveAsLssBytes());
-                    this.props.eventSink.markAsUnmodified();
-                },
-                this.props.openedSplitsKey,
-            );
-            if (this.props.openedSplitsKey !== openedSplitsKey) {
-                this.props.callbacks.setSplitsKey(openedSplitsKey);
-            }
-            this.refreshDb();
-        } catch (_) {
-            toast.error("Failed to save the splits.");
-        }
+        await this.props.callbacks.saveSplits();
+        this.refreshDb();
     }
 
     private async uploadSplitsToSplitsIO(key: number): Promise<Option<Window>> {

--- a/src/util/AutoRefresh.tsx
+++ b/src/util/AutoRefresh.tsx
@@ -8,10 +8,10 @@ export interface Props {
 }
 
 export default class AutoRefresh extends React.Component<Props> {
-    private reqId: number | null = null;
+    private reqId?: number;
     private previousTime: number = 0;
 
-    public componentWillMount() {
+    public componentDidMount() {
         this.startAnimation();
     }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,7 +16,7 @@ import * as sass from "sass";
 function parseChangelog() {
     return execSync("git log --grep \"^Changelog: \" -10")
         .toString()
-        .split(/^commit /)
+        .split(/^commit /m)
         .slice(1)
         .map((commit) => {
             const changelogIndex = commit.indexOf("    Changelog: ");


### PR DESCRIPTION
This adds a save on reset setting to the general settings. When enabled, the splits are automatically saved when the timer is reset.

Changelog: You can now enable **Save On Reset** in the settings, which will automatically save the splits when you reset the timer.