### PR TITLE
Allow choosing comparisons from a list

### DIFF
--- a/src/css/Sidebar.scss
+++ b/src/css/Sidebar.scss
@@ -3,7 +3,8 @@
 @import 'Toggle';
 @import 'variables';
 
-$header-font-size: 24px;
+$h1-font-size: 24px;
+$h2-font-size: 22px;
 
 .sidebar-overlay {
   z-index: 3 !important;
@@ -17,7 +18,7 @@ $header-font-size: 24px;
 
   @include toggle;
 
-  > div > div.small > button {
+  >div>div.small>button {
     width: 50%;
     font-size: 18px;
   }
@@ -32,18 +33,23 @@ $header-font-size: 24px;
       }
     }
 
-    h1, h2 {
-      font-size: $header-font-size;
+    h1,
+    h2 {
       text-align: center;
       margin-top: $ui-large-margin;
       margin-bottom: $ui-large-margin;
     }
 
-    h2 {
-      margin-bottom: $ui-large-margin - math.div($ui-margin, 2);
+    h1 {
+      font-size: $h1-font-size;
     }
 
-    > button {
+    h2 {
+      font-size: $h2-font-size;
+      margin-bottom: $ui-margin;
+    }
+
+    >button {
       width: 100%;
     }
 
@@ -64,19 +70,19 @@ $header-font-size: 24px;
   }
 
   .choose-comparison {
-    > button {
-      width: 30px;
-      font-size: 28px;
-    }
-
-    > span {
-      width: calc(100% - 60px);
-      text-align: center;
-      display: inline-block;
-      font-size: 20px;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
+    margin-bottom: math.div($ui-margin, 2);
+    padding: 0 6px 0 6px;
+    width: 100%;
+    height: 40px;
+    appearance: none;
+    background: $button-middle-color;
+    border: 1px solid $border-color;
+    border-radius: 5px;
+    color: white;
+    cursor: pointer;
+    font-family: "fira", sans-serif;
+    font-size: 20px;
+    text-align: center;
+    text-overflow: ellipsis;
   }
 }

--- a/src/css/variables.scss
+++ b/src/css/variables.scss
@@ -13,6 +13,7 @@ $border-color: #404040;
 
 $button-active-color: linear-gradient(hsl(0, 0%, 13%) 0%, hsl(0, 0%, 23%) 100%);
 $button-color: linear-gradient(hsl(0, 0%, 11%) 0%, hsl(0, 0%, 7%) 100%);
+$button-middle-color: hsl(0, 0%, 9%);
 $button-disabled-color: #222;
 $button-disabled-text-color: #666;
 $button-hover-color: linear-gradient(hsl(0, 0%, 14%) 0%, hsl(0, 0%, 9%) 100%);

--- a/src/ui/LSOEventSink.ts
+++ b/src/ui/LSOEventSink.ts
@@ -10,6 +10,7 @@ export class LSOEventSink {
         private currentTimingMethodChanged: () => void,
         private currentPhaseChanged: () => void,
         private currentSplitChanged: () => void,
+        private comparisonListChanged: () => void,
         private onReset: () => void,
     ) {
         this.eventSink = new EventSink(new WebEventSink(this).intoGeneric());
@@ -106,6 +107,11 @@ export class LSOEventSink {
         this.currentComparisonChanged();
     }
 
+    public setCurrentComparison(comparison: string): void {
+        this.timer.setCurrentComparison(comparison);
+        this.currentComparisonChanged();
+    }
+
     public toggleTimingMethod(): void {
         this.timer.toggleTimingMethod();
         this.currentTimingMethodChanged();
@@ -160,6 +166,7 @@ export class LSOEventSink {
         this.currentComparisonChanged();
         this.currentPhaseChanged();
         this.currentSplitChanged();
+        this.comparisonListChanged();
 
         return result;
     }
@@ -214,6 +221,16 @@ export class LSOEventSink {
 
     public currentComparison(): string {
         return this.timer.currentComparison();
+    }
+
+    public getAllComparisons(): string[] {
+        const run = this.timer.getRun();
+        const len = run.comparisonsLen();
+        const comparisons = [];
+        for (let i = 0; i < len; i++) {
+            comparisons.push(run.comparison(i));
+        }
+        return comparisons;
     }
 
     public currentTimingMethod(): TimingMethod {

--- a/src/ui/LayoutEditor.tsx
+++ b/src/ui/LayoutEditor.tsx
@@ -18,6 +18,7 @@ export interface Props {
     layoutWidth: number,
     layoutHeight: number,
     generalSettings: GeneralSettings,
+    allComparisons: string[],
     isDesktop: boolean,
     eventSink: LSOEventSink,
     renderer: WebRenderer,
@@ -103,6 +104,7 @@ export class LayoutEditor extends React.Component<Props, State> {
                     factory={LiveSplit.SettingValue}
                     state={this.state.editor.component_settings}
                     editorUrlCache={this.props.layoutEditorUrlCache}
+                    allComparisons={this.props.allComparisons}
                     setValue={(index, value) => {
                         this.props.editor.setComponentSettingsValue(index, value);
                         this.update();
@@ -114,6 +116,7 @@ export class LayoutEditor extends React.Component<Props, State> {
                     factory={LiveSplit.SettingValue}
                     state={this.state.editor.general_settings}
                     editorUrlCache={this.props.layoutEditorUrlCache}
+                    allComparisons={this.props.allComparisons}
                     setValue={(index, value) => {
                         this.props.editor.setGeneralSettingsValue(
                             index,

--- a/src/ui/LayoutView.tsx
+++ b/src/ui/LayoutView.tsx
@@ -26,6 +26,7 @@ export interface Props {
     currentTimingMethod: TimingMethod,
     currentPhase: TimerPhase,
     currentSplitIndex: number,
+    allComparisons: string[],
 }
 
 interface Callbacks {
@@ -67,6 +68,7 @@ export class LayoutView extends React.Component<Props> {
             currentTimingMethod={this.props.currentTimingMethod}
             currentPhase={this.props.currentPhase}
             currentSplitIndex={this.props.currentSplitIndex}
+            allComparisons={this.props.allComparisons}
         />;
         const sidebarContent = this.renderSidebarContent();
         return this.props.callbacks.renderViewWithSidebar(renderedView, sidebarContent);

--- a/src/ui/LiveSplit.tsx
+++ b/src/ui/LiveSplit.tsx
@@ -84,6 +84,7 @@ export interface State {
     currentTimingMethod: TimingMethod,
     currentPhase: TimerPhase,
     currentSplitIndex: number,
+    allComparisons: string[],
 }
 
 export let hotkeySystem: Option<HotkeySystem> = null;
@@ -129,6 +130,7 @@ export class LiveSplit extends React.Component<Props, State> {
             () => this.currentTimingMethodChanged(),
             () => this.currentPhaseChanged(),
             () => this.currentSplitChanged(),
+            () => this.comparisonsListChanged(),
             () => this.onReset(),
         );
 
@@ -208,6 +210,7 @@ export class LiveSplit extends React.Component<Props, State> {
             currentTimingMethod: eventSink.currentTimingMethod(),
             currentPhase: eventSink.currentPhase(),
             currentSplitIndex: eventSink.currentSplitIndex(),
+            allComparisons: eventSink.getAllComparisons(),
         };
 
         this.mediaQueryChanged = this.mediaQueryChanged.bind(this);
@@ -294,6 +297,7 @@ export class LiveSplit extends React.Component<Props, State> {
                 editor={this.state.menu.editor}
                 callbacks={this}
                 runEditorUrlCache={this.state.runEditorUrlCache}
+                allComparisons={this.state.allComparisons}
                 generalSettings={this.state.generalSettings}
             />;
         } else if (this.state.menu.kind === MenuKind.LayoutEditor) {
@@ -305,6 +309,7 @@ export class LiveSplit extends React.Component<Props, State> {
                 layoutWidth={this.state.layoutWidth}
                 layoutHeight={this.state.layoutHeight}
                 generalSettings={this.state.generalSettings}
+                allComparisons={this.state.allComparisons}
                 isDesktop={this.state.isDesktop}
                 eventSink={this.state.eventSink}
                 renderer={this.state.renderer}
@@ -318,6 +323,7 @@ export class LiveSplit extends React.Component<Props, State> {
                 callbacks={this}
                 eventSink={this.state.eventSink}
                 serverConnection={this.state.serverConnection}
+                allComparisons={this.state.allComparisons}
             />;
         } else if (this.state.menu.kind === MenuKind.About) {
             return <About callbacks={this} />;
@@ -347,6 +353,7 @@ export class LiveSplit extends React.Component<Props, State> {
                 currentTimingMethod={this.state.currentTimingMethod}
                 currentPhase={this.state.currentPhase}
                 currentSplitIndex={this.state.currentSplitIndex}
+                allComparisons={this.state.allComparisons}
             />;
         } else if (this.state.menu.kind === MenuKind.Layout) {
             return <LayoutView
@@ -367,6 +374,7 @@ export class LiveSplit extends React.Component<Props, State> {
                 currentTimingMethod={this.state.currentTimingMethod}
                 currentPhase={this.state.currentPhase}
                 currentSplitIndex={this.state.currentSplitIndex}
+                allComparisons={this.state.allComparisons}
             />;
         }
         // Only get here if the type is invalid
@@ -771,6 +779,14 @@ export class LiveSplit extends React.Component<Props, State> {
         if (this.state != null) {
             this.setState({
                 currentSplitIndex: this.state.eventSink.currentSplitIndex(),
+            });
+        }
+    }
+
+    comparisonsListChanged(): void {
+        if (this.state != null) {
+            this.setState({
+                allComparisons: this.state.eventSink.getAllComparisons(),
             });
         }
     }

--- a/src/ui/RunEditor.tsx
+++ b/src/ui/RunEditor.tsx
@@ -28,6 +28,7 @@ export interface Props {
     editor: LiveSplit.RunEditor,
     callbacks: Callbacks,
     runEditorUrlCache: UrlCache,
+    allComparisons: string[],
     generalSettings: GeneralSettings,
 }
 export interface State {
@@ -819,6 +820,7 @@ export class RunEditor extends React.Component<Props, State> {
                     factory={new JsonSettingValueFactory()}
                     state={{ fields }}
                     editorUrlCache={this.props.runEditorUrlCache}
+                    allComparisons={this.props.allComparisons}
                     setValue={(index, value) => {
                         function unwrapString(value: ExtendedSettingsDescriptionValueJson): string {
                             if ("String" in value) {

--- a/src/ui/Settings.tsx
+++ b/src/ui/Settings.tsx
@@ -18,6 +18,7 @@ export interface Props<T> {
     state: ExtendedSettingsDescriptionJson,
     factory: SettingValueFactory<T>,
     editorUrlCache: UrlCache,
+    allComparisons: string[],
 }
 
 export interface ExtendedSettingsDescriptionJson {
@@ -257,44 +258,72 @@ export class SettingsComponent<T> extends React.Component<Props<T>> {
                     </div>
                 );
             } else if ("OptionalString" in value) {
-                const children = [
-                    <ToggleCheckbox
-                        value={value.OptionalString !== null}
-                        setValue={(value) => {
-                            if (value) {
-                                this.props.setValue(
-                                    valueIndex,
-                                    factory.fromOptionalString(""),
-                                );
-                            } else {
-                                this.props.setValue(
-                                    valueIndex,
-                                    factory.fromOptionalEmptyString(),
-                                );
-                            }
-                        }}
-                    />,
-                ];
-
-                if (value.OptionalString !== null) {
-                    children.push(
-                        <input
-                            value={value.OptionalString}
+                // FIXME: This is a hack that we need for now until the way
+                // settings are represented is refactored.
+                if (typeof (field.text) === "string" && /^Comparison( \d)?$/.test(field.text)) {
+                    component = <div className="settings-value-box">
+                        <select
+                            value={value.OptionalString ?? ""}
                             onChange={(e) => {
-                                this.props.setValue(
-                                    valueIndex,
-                                    factory.fromOptionalString(e.target.value),
-                                );
+                                if (e.target.value !== "") {
+                                    this.props.setValue(
+                                        valueIndex,
+                                        factory.fromOptionalString(e.target.value),
+                                    );
+                                } else {
+                                    this.props.setValue(
+                                        valueIndex,
+                                        factory.fromOptionalEmptyString(),
+                                    );
+                                }
+                            }}
+                        >
+                            <option value="">Current Comparison</option>
+                            {this.props.allComparisons.map((comparison) =>
+                                <option>{comparison}</option>
+                            )}
+                        </select>
+                    </div>;
+                } else {
+                    const children = [
+                        <ToggleCheckbox
+                            value={value.OptionalString !== null}
+                            setValue={(value) => {
+                                if (value) {
+                                    this.props.setValue(
+                                        valueIndex,
+                                        factory.fromOptionalString(""),
+                                    );
+                                } else {
+                                    this.props.setValue(
+                                        valueIndex,
+                                        factory.fromOptionalEmptyString(),
+                                    );
+                                }
                             }}
                         />,
+                    ];
+
+                    if (value.OptionalString !== null) {
+                        children.push(
+                            <input
+                                value={value.OptionalString}
+                                onChange={(e) => {
+                                    this.props.setValue(
+                                        valueIndex,
+                                        factory.fromOptionalString(e.target.value),
+                                    );
+                                }}
+                            />,
+                        );
+                    }
+
+                    component = (
+                        <div className="settings-value-box optional-value">
+                            {children}
+                        </div>
                     );
                 }
-
-                component = (
-                    <div className="settings-value-box optional-value">
-                        {children}
-                    </div>
-                );
             } else if ("RemovableString" in value) {
                 component = (
                     <div className="settings-value-box removable-string">

--- a/src/ui/SettingsEditor.tsx
+++ b/src/ui/SettingsEditor.tsx
@@ -28,6 +28,7 @@ export interface Props {
     callbacks: Callbacks,
     serverConnection: Option<LiveSplitServer>,
     eventSink: LSOEventSink,
+    allComparisons: string[],
 }
 
 export interface State {
@@ -68,6 +69,7 @@ export class SettingsEditor extends React.Component<Props, State> {
                     factory={SettingValue}
                     state={this.state.settings}
                     editorUrlCache={this.props.urlCache}
+                    allComparisons={this.props.allComparisons}
                     setValue={(index, value) => {
                         if (!this.props.hotkeyConfig.setValue(index, value)) {
                             toast.error("The hotkey is already in use.");
@@ -113,6 +115,7 @@ export class SettingsEditor extends React.Component<Props, State> {
                         ],
                     }}
                     editorUrlCache={this.props.urlCache}
+                    allComparisons={this.props.allComparisons}
                     setValue={(index, value) => {
                         switch (index) {
                             case 0:
@@ -196,6 +199,7 @@ export class SettingsEditor extends React.Component<Props, State> {
                         ],
                     }}
                     editorUrlCache={this.props.urlCache}
+                    allComparisons={this.props.allComparisons}
                     setValue={(index, value) => {
                         switch (index) {
                             case 0:

--- a/src/ui/TimerView.tsx
+++ b/src/ui/TimerView.tsx
@@ -32,6 +32,7 @@ export interface Props {
     currentTimingMethod: TimingMethod,
     currentPhase: TimerPhase,
     currentSplitIndex: number,
+    allComparisons: string[],
 }
 export interface State {
     manualGameTime: string,
@@ -214,21 +215,13 @@ export class TimerView extends React.Component<Props, State> {
                 </button>
                 <hr />
                 <h2>Compare Against</h2>
-                <div className="choose-comparison">
-                    <button
-                        aria-label="Switch to Previous Comparison"
-                        onClick={(_) => this.props.eventSink.switchToPreviousComparison()}
-                    >
-                        <i className="fa fa-caret-left" aria-hidden="true" />
-                    </button>
-                    <span>{this.props.currentComparison}</span>
-                    <button
-                        aria-label="Switch to Next Comparison"
-                        onClick={(_) => this.props.eventSink.switchToNextComparison()}
-                    >
-                        <i className="fa fa-caret-right" aria-hidden="true" />
-                    </button>
-                </div>
+                <select
+                    value={this.props.currentComparison}
+                    onChange={(e) => this.props.eventSink.setCurrentComparison(e.target.value)}
+                    className="choose-comparison"
+                >
+                    {this.props.allComparisons.map((comparison) => <option>{comparison}</option>)}
+                </select>
                 <div className="small">
                     <button
                         onClick={(_) => {


### PR DESCRIPTION
This changes the way the user chooses the comparisons. This affects both the sidebar and the way you specify comparison overrides for the components. In both cases you now choose the comparison from a list of all the comparisons that are available.

Changelog: You can now choose the comparisons from a list in the sidebar. Settings that allow you to specify a comparison now also provide a list to choose from.