### PR TITLE
Add indicators for unsaved changes

### DIFF
--- a/src/css/Sidebar.scss
+++ b/src/css/Sidebar.scss
@@ -67,6 +67,12 @@ $h2-font-size: 22px;
         }
       }
     }
+
+    .modified-icon {
+      position: absolute;
+      font-size: 10px;
+      padding-left: 5px;
+    }
   }
 
   .choose-comparison {

--- a/src/ui/LSOEventSink.ts
+++ b/src/ui/LSOEventSink.ts
@@ -11,6 +11,7 @@ export class LSOEventSink {
         private currentPhaseChanged: () => void,
         private currentSplitChanged: () => void,
         private comparisonListChanged: () => void,
+        private splitsModifiedChanged: () => void,
         private onReset: () => void,
     ) {
         this.eventSink = new EventSink(new WebEventSink(this).intoGeneric());
@@ -30,6 +31,7 @@ export class LSOEventSink {
 
         this.currentPhaseChanged();
         this.currentSplitChanged();
+        this.splitsModifiedChanged();
     }
 
     public split(): void {
@@ -44,6 +46,7 @@ export class LSOEventSink {
 
         this.currentPhaseChanged();
         this.currentSplitChanged();
+        this.splitsModifiedChanged();
     }
 
     public reset(): void {
@@ -167,6 +170,7 @@ export class LSOEventSink {
         this.currentPhaseChanged();
         this.currentSplitChanged();
         this.comparisonListChanged();
+        this.splitsModifiedChanged();
 
         return result;
     }
@@ -177,6 +181,7 @@ export class LSOEventSink {
 
     public markAsUnmodified(): void {
         this.timer.markAsUnmodified();
+        this.splitsModifiedChanged();
     }
 
     public getRun(): RunRef {

--- a/src/ui/LayoutView.tsx
+++ b/src/ui/LayoutView.tsx
@@ -27,6 +27,8 @@ export interface Props {
     currentPhase: TimerPhase,
     currentSplitIndex: number,
     allComparisons: string[],
+    splitsModified: boolean,
+    layoutModified: boolean,
 }
 
 interface Callbacks {
@@ -69,6 +71,8 @@ export class LayoutView extends React.Component<Props> {
             currentPhase={this.props.currentPhase}
             currentSplitIndex={this.props.currentSplitIndex}
             allComparisons={this.props.allComparisons}
+            splitsModified={this.props.splitsModified}
+            layoutModified={this.props.layoutModified}
         />;
         const sidebarContent = this.renderSidebarContent();
         return this.props.callbacks.renderViewWithSidebar(renderedView, sidebarContent);
@@ -84,6 +88,10 @@ export class LayoutView extends React.Component<Props> {
                 </button>
                 <button onClick={(_) => this.props.callbacks.saveLayout()}>
                     <i className="fa fa-save" aria-hidden="true" /> Save
+                    {
+                        this.props.layoutModified &&
+                        <i className="fa fa-circle modified-icon" aria-hidden="true" />
+                    }
                 </button>
                 <button onClick={(_) => this.props.callbacks.importLayout()}>
                     <i className="fa fa-download" aria-hidden="true" /> Import

--- a/src/ui/SplitsSelection.tsx
+++ b/src/ui/SplitsSelection.tsx
@@ -25,6 +25,7 @@ export interface Props {
     openedSplitsKey?: number,
     callbacks: Callbacks,
     generalSettings: GeneralSettings,
+    splitsModified: boolean,
 }
 
 interface State {
@@ -195,6 +196,10 @@ export class SplitsSelection extends React.Component<Props, State> {
                 </button>
                 <button onClick={(_) => this.saveSplits()}>
                     <i className="fa fa-save" aria-hidden="true" /> Save
+                    {
+                        this.props.splitsModified &&
+                        <i className="fa fa-circle modified-icon" aria-hidden="true" />
+                    }
                 </button>
                 <button onClick={(_) => this.exportTimerSplits()}>
                     <i className="fa fa-upload" aria-hidden="true" /> Export

--- a/src/ui/TimerView.tsx
+++ b/src/ui/TimerView.tsx
@@ -33,6 +33,8 @@ export interface Props {
     currentPhase: TimerPhase,
     currentSplitIndex: number,
     allComparisons: string[],
+    splitsModified: boolean,
+    layoutModified: boolean,
 }
 export interface State {
     manualGameTime: string,
@@ -209,9 +211,17 @@ export class TimerView extends React.Component<Props, State> {
                 <hr className="livesplit-title-separator" />
                 <button onClick={(_) => this.props.callbacks.openSplitsView()}>
                     <i className="fa fa-list" aria-hidden="true" /> Splits
+                    {
+                        this.props.splitsModified &&
+                        <i className="fa fa-circle modified-icon" aria-hidden="true" />
+                    }
                 </button>
                 <button onClick={(_) => this.props.callbacks.openLayoutView()}>
                     <i className="fa fa-layer-group" aria-hidden="true" /> Layout
+                    {
+                        this.props.layoutModified &&
+                        <i className="fa fa-circle modified-icon" aria-hidden="true" />
+                    }
                 </button>
                 <hr />
                 <h2>Compare Against</h2>


### PR DESCRIPTION
This adds indicators to various parts of the UI to indicate that there are unsaved changes. The indicators are mainly shown as white dots in the sidebar highlighting what is unsaved. The title is also updated to reflect this. The Badging API is also used to show a badge on the "app icon" if it's installed as a PWA. In addition to the splits, the layouts are also now properly tracked when it comes to unsaved changes.

Changelog: There are now indicators in the user interface that remind you about unsaved changes to your splits and layouts.