### PR TITLE
Save the layout dimensions when saving layout

### DIFF
--- a/src/storage/index.tsx
+++ b/src/storage/index.tsx
@@ -185,10 +185,16 @@ export async function copySplits(key: number) {
     await tx.done;
 }
 
-export async function storeLayout(layout: LayoutSettings) {
+export async function storeLayout(
+    layout: LayoutSettings,
+    layoutWidth: number,
+    layoutHeight: number,
+) {
     const db = await getDb();
 
     await db.put("settings", layout, "layout");
+    await db.put("settings", layoutWidth, "layoutWidth");
+    await db.put("settings", layoutHeight, "layoutHeight");
 }
 
 export async function loadLayout(): Promise<LayoutSettings | undefined> {
@@ -207,13 +213,6 @@ export async function loadHotkeys(): Promise<HotkeyConfigSettings | undefined> {
     const db = await getDb();
 
     return await db.get("settings", "hotkeys");
-}
-
-export async function storeLayoutDims(layoutWidth: number, layoutHeight: number) {
-    const db = await getDb();
-
-    await db.put("settings", layoutWidth, "layoutWidth");
-    await db.put("settings", layoutHeight, "layoutHeight");
 }
 
 export async function loadLayoutDims(): Promise<[number, number]> {

--- a/src/ui/LayoutEditor.tsx
+++ b/src/ui/LayoutEditor.tsx
@@ -30,7 +30,7 @@ export interface State {
 }
 
 interface Callbacks {
-    onResize(width: number, height: number): Promise<void>,
+    onResize(width: number, height: number): void,
     renderViewWithSidebar(renderedView: JSX.Element, sidebarContent: JSX.Element): JSX.Element,
     closeLayoutEditor(save: boolean): void,
 }

--- a/src/ui/LayoutView.tsx
+++ b/src/ui/LayoutView.tsx
@@ -37,7 +37,7 @@ interface Callbacks {
     importLayoutFromFile(file: File): Promise<void>,
     importSplitsFromFile(file: File): Promise<void>,
     loadDefaultLayout(): void,
-    onResize(width: number, height: number): Promise<void>,
+    onResize(width: number, height: number): void,
     openAboutView(): void,
     openLayoutEditor(): void,
     openLayoutView(): void,

--- a/src/ui/LiveSplit.tsx
+++ b/src/ui/LiveSplit.tsx
@@ -459,7 +459,11 @@ export class LiveSplit extends React.Component<Props, State> {
     public async saveLayout() {
         try {
             const layout = this.state.layout.settingsAsJson();
-            await Storage.storeLayout(layout);
+            await Storage.storeLayout(
+                layout,
+                this.state.storedLayoutWidth,
+                this.state.storedLayoutHeight,
+            );
             this.setState({ layoutModified: false }, () => this.updateBadge());
         } catch (_) {
             toast.error("Failed to save the layout.");
@@ -600,14 +604,17 @@ export class LiveSplit extends React.Component<Props, State> {
         this.openTimerView();
     }
 
-    public async onResize(width: number, height: number) {
-        this.setState({
-            layoutWidth: width,
-            layoutHeight: height,
-            storedLayoutWidth: width,
-            storedLayoutHeight: height,
-        });
-        await Storage.storeLayoutDims(width, height);
+    public onResize(width: number, height: number) {
+        this.setState(
+            {
+                layoutWidth: width,
+                layoutHeight: height,
+                storedLayoutWidth: width,
+                storedLayoutHeight: height,
+                layoutModified: true,
+            },
+            () => this.updateBadge(),
+        );
     }
 
     private getDefaultRun() {

--- a/src/ui/TimerView.tsx
+++ b/src/ui/TimerView.tsx
@@ -43,7 +43,7 @@ export interface State {
 interface Callbacks {
     importLayoutFromFile(file: File): Promise<void>,
     importSplitsFromFile(file: File): Promise<void>,
-    onResize(width: number, height: number): Promise<void>,
+    onResize(width: number, height: number): void,
     openAboutView(): void,
     openLayoutView(): void,
     openSplitsView(): void,


### PR DESCRIPTION
This changes it so the layout dimensions are not immediately saved when resizing a layout. Instead they are saved when saving the layout. Additionally resizing marks the layout as unsaved, so you don't forget about saving the new dimensions.