### PR TITLE
Fix some small bugs

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -49,9 +49,9 @@ try {
             generalSettings,
         } = await LiveSplit.loadStoredData();
 
-        function requestWakeLock() {
+        async function requestWakeLock() {
             try {
-                (navigator as any)?.wakeLock?.request("screen");
+                await (navigator as any)?.wakeLock?.request();
             } catch {
                 // It's fine if it fails.
             }

--- a/src/ui/LSOEventSink.ts
+++ b/src/ui/LSOEventSink.ts
@@ -80,6 +80,7 @@ export class LSOEventSink {
 
         this.currentPhaseChanged();
         this.currentSplitChanged();
+        this.splitsModifiedChanged();
     }
 
     public pause(): void {

--- a/src/ui/LiveSplit.tsx
+++ b/src/ui/LiveSplit.tsx
@@ -828,7 +828,13 @@ export class LiveSplit extends React.Component<Props, State> {
             } catch {
                 // It's fine if this fails.
             }
-            document.title = "*LiveSplit One";
+
+            // It's important that any change is at the end of the title,
+            // because at least Chrome then recognizes that it's an extension of
+            // the PWA name. Otherwise it would show:
+            // LiveSplit One - Window Title
+            // which would repeat LiveSplit One.
+            document.title = "LiveSplit One ●";
         } else {
             try {
                 navigator?.clearAppBadge();


### PR DESCRIPTION
The APIs that are not supported by every browser or may not always be allowed (Battery and Wake Lock) are requested in try catch blocks. The problem was that both of them actually yield promises. If the promises fail, then those exceptions would not be caught properly, because we forgot to await them. So especially for the wake lock you would sometimes see an error message when it gets hot reloaded. This should be fixed now.

Additionally this changes the window title for when there are unsaved changes. Apparently when LiveSplit One is used as a PWA, then at least Chrome wants to always keep the app name in the title. If the title itself is changed, then it gets shown as `LiveSplit One - The new title`. By us putting an asterisk in the front of the title, the PWA then shows `LiveSplit One - *LiveSplit One`, which is pretty bad. I noticed that if the app name is also the prefix of the title, Chrome recognizes that and does not end up showing the app name twice.

There also was a small bug in the event sink where the `togglePauseOrStart` event did not update the splits modified state.