### PR TITLE
Skip update prompts in invalid situations

### DIFF
--- a/src/ui/LiveSplit.tsx
+++ b/src/ui/LiveSplit.tsx
@@ -222,13 +222,17 @@ export class LiveSplit extends React.Component<Props, State> {
     }
 
     private notifyAboutUpdate(this: void) {
-        toast.warn(
-            'A new version of LiveSplit One is available! Click here to reload.',
-            {
-                closeOnClick: true,
-                onClick: () => window.location.reload(),
-            },
-        );
+        const { serviceWorker } = navigator;
+        if (serviceWorker && serviceWorker.controller) {
+            // Don't prompt for update when service worker gets removed
+            toast.warn(
+                'A new version of LiveSplit One is available! Click here to reload.',
+                {
+                    closeOnClick: true,
+                    onClick: () => window.location.reload(),
+                },
+            );
+        }
     }
 
     public componentDidMount() {
@@ -258,7 +262,8 @@ export class LiveSplit extends React.Component<Props, State> {
         this.handleAutomaticResize();
 
         const { serviceWorker } = navigator;
-        if (serviceWorker) {
+        if (serviceWorker && serviceWorker.controller) {
+            // Don't prompt for update when there was no service worker previously installed
             serviceWorker.addEventListener('controllerchange', this.notifyAboutUpdate);
         }
     }


### PR DESCRIPTION
When it's the first install of the service worker, or when the user clears the site data, the `controllerchange` event gets triggered. However, in these situations, we want to avoid prompting the user about an update.

Resolves #913 