### PR TITLE
Allow copying comparisons

### DIFF
--- a/src/ui/HotkeyButton.tsx
+++ b/src/ui/HotkeyButton.tsx
@@ -49,7 +49,10 @@ export default class HotkeyButton extends React.Component<Props, State> {
                     onClick={() => this.focusButton()}
                 >
                     {buttonText}
-                    <span className="tooltip-text">Click to record a hotkey. You may also use buttons on a gamepad.</span>
+                    <span className="tooltip-text">
+                        Click to record a hotkey. You may also use buttons on a gamepad.
+                        Global hotkeys are currently not possible. Gamepad buttons work globally.
+                    </span>
                 </button>
                 {
                     map(this.props.value, () => (


### PR DESCRIPTION
This adds functionality to the run editor to allow copying comparisons. This is not only useful for copying custom comparisons, but also for "baking" the times of a generated comparison, such as the `Latest Run` or the `Average Segments` to a custom comparison that you can keep around as long as you want. This is somewhat also meant to replace the functionality of storing the current run as a Personal Best. Instead you can just store the `Latest Run` as a custom comparison after you are done with it.

Changelog: The splits editor now allows copying comparisons. This can also be used to keep the times of an automatic comparison around as a custom comparison. One example for using this is keeping around the latest run as a custom comparison, so that you can compare against it later on, even if you have already done another run.