### PR TITLE
Fix the margin for the PWA Icon on iOS

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -120,6 +120,10 @@ export default async (env, argv) => {
                     theme_color: "#232323",
                     appleStatusBarStyle: "black-translucent",
                     icons: {
+                        appleIcon: {
+                            offset: 10,
+                        },
+                        windows: false,
                         coast: false,
                         yandex: false,
                     },


### PR DESCRIPTION
This adjusts the margin for the PWA Icon on iOS to roughly match the Apple guidelines, but more importantly, to just finally look good.

![image](https://github.com/LiveSplit/LiveSplitOne/assets/1451630/9d8166a1-beeb-45e2-82cf-b4aa7fa6d60f)