### PR TITLE
Use background for Android icon

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -123,6 +123,10 @@ export default async (env, argv) => {
                         appleIcon: {
                             offset: 10,
                         },
+                        android: {
+                            background: true,
+                            offset: 10,
+                        },
                         windows: false,
                         coast: false,
                         yandex: false,


### PR DESCRIPTION
Before:
![Screenshot_20240608_120234_One UI Home](https://github.com/LiveSplit/LiveSplitOne/assets/8262173/bfd0243b-fcab-4bfc-b6f0-e8a1c165efb0)

After:
![Screenshot_20240608_131916_One UI Home](https://github.com/LiveSplit/LiveSplitOne/assets/8262173/a8353d31-268b-4f7a-8edc-4c1fc33f30a4)

I had to specify `offset` as well because it looked bad without it:
![Screenshot_20240608_131226_One UI Home](https://github.com/LiveSplit/LiveSplitOne/assets/8262173/2f23e730-64e8-4180-8e04-9825692a6845)
