### PR TITLE
Store the comparison and timing method

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -43,6 +43,8 @@ try {
             splits,
             splitsKey,
             layout,
+            comparison,
+            timingMethod,
             hotkeys,
             layoutWidth,
             layoutHeight,
@@ -88,6 +90,8 @@ try {
                 <LiveSplit
                     splits={splits}
                     layout={layout}
+                    comparison={comparison}
+                    timingMethod={timingMethod}
                     hotkeys={hotkeys}
                     splitsKey={splitsKey}
                     layoutWidth={layoutWidth}

--- a/src/storage/index.tsx
+++ b/src/storage/index.tsx
@@ -1,6 +1,6 @@
 import { openDB, IDBPDatabase } from "idb";
 import { Option, assert } from "../util/OptionUtil";
-import { RunRef, Run } from "../livesplit-core";
+import { RunRef, Run, TimingMethod } from "../livesplit-core";
 import { GeneralSettings } from "../ui/SettingsEditor";
 import { FRAME_RATE_AUTOMATIC } from "../util/FrameRate";
 
@@ -256,4 +256,28 @@ export async function loadGeneralSettings(): Promise<GeneralSettings> {
         splitsIoIntegration: generalSettings.splitsIoIntegration ?? true,
         serverUrl: generalSettings.serverUrl,
     };
+}
+
+export async function storeTimingMethod(timingMethod: TimingMethod) {
+    const db = await getDb();
+
+    await db.put("settings", timingMethod, "timingMethod");
+}
+
+export async function loadTimingMethod(): Promise<TimingMethod> {
+    const db = await getDb();
+
+    return await db.get("settings", "timingMethod") ?? TimingMethod.RealTime;
+}
+
+export async function storeComparison(comparison: string) {
+    const db = await getDb();
+
+    await db.put("settings", comparison, "comparison");
+}
+
+export async function loadComparison(): Promise<string | undefined> {
+    const db = await getDb();
+
+    return await db.get("settings", "comparison");
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -123,6 +123,9 @@ export default async (env, argv) => {
                         appleIcon: {
                             offset: 10,
                         },
+                        appleStartup: {
+                            offset: 15,
+                        },
                         android: {
                             background: true,
                             offset: 10,


### PR DESCRIPTION
We now automatically store the current comparison and timing method into the Indexed DB. This allows us to restore the comparison and timing method when the user reloads the page.

Changelog: The comparison and timing method (Real Time / Game Time) that you choose now stay chosen when you reload LiveSplit One.