### PR TITLE
Enable the WebAssembly Multivalue feature

### DIFF
--- a/buildCore.js
+++ b/buildCore.js
@@ -31,9 +31,7 @@ if (process.argv.some((v) => v === "--unstable")) {
 if (process.argv.some((v) => v === "--nightly")) {
     toolchain = "+nightly";
     cargoFlags += " -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort";
-    // Multivalue is not supported by wasm-bindgen yet:
-    // https://github.com/rustwasm/wasm-bindgen/issues/3552
-    // rustFlags += ",+multivalue";
+    rustFlags += ",+multivalue -Z wasm-c-abi=spec";
 
     // Virtual function elimination requires LTO, so we can only do it for
     // max-opt builds.


### PR DESCRIPTION
This enables the multivalue feature when building with the nightly Rust compiler. This is because the Rust standard library is not built with the multivalue feature enabled by default. Also we need to specifically use the spec compliant C ABI for it to work, which is also nightly only.