### PR TITLE
Introduce Custom Dialogs

### DIFF
--- a/src/api/GameList.ts
+++ b/src/api/GameList.ts
@@ -110,6 +110,10 @@ export async function downloadGameInfo(gameName: string): Promise<void> {
     }
 }
 
+export function gameListLength(): number {
+    return gameList.length;
+}
+
 export function downloadGameList(): Promise<void> {
     if (gameListPromise == null) {
         gameListPromise = (async () => {
@@ -127,6 +131,10 @@ export function downloadGameList(): Promise<void> {
     return gameListPromise;
 }
 
+export function platformListLength(): number {
+    return platformList.size;
+}
+
 export function downloadPlatformList(): Promise<void> {
     if (platformListPromise == null) {
         platformListPromise = (async () => {
@@ -137,6 +145,10 @@ export function downloadPlatformList(): Promise<void> {
         })();
     }
     return platformListPromise;
+}
+
+export function regionListLength(): number {
+    return regionList.size;
 }
 
 export function downloadRegionList(): Promise<void> {

--- a/src/css/Dialog.scss
+++ b/src/css/Dialog.scss
@@ -1,0 +1,52 @@
+@import 'variables';
+
+dialog {
+    color: #eee;
+    background: $main-background-color;
+    border: 2px solid $border-color;
+    border-radius: 10px;
+    min-width: 225px;
+    max-width: 400px;
+    padding: $ui-large-margin;
+
+    h1 {
+        font-size: 20px;
+        margin: 5px 0;
+    }
+
+    .buttons {
+        button {
+            font-size: 16px;
+            margin: 0;
+            min-width: 80px;
+
+            &:focus {
+                border-color: #888;
+            }
+        }
+
+        display: flex;
+        flex-direction: row;
+        justify-content: flex-end;
+        column-gap: $ui-margin;
+    }
+
+    &::backdrop {
+        background: rgba(0, 0, 0, 0.5);
+    }
+
+    input {
+        width: 100%;
+        border: none;
+        border-bottom: 1px solid hsla(0, 0%, 100%, 0.25);
+        background: transparent;
+        color: white;
+        text-overflow: ellipsis;
+        font-family: "fira", sans-serif;
+        font-size: 16px;
+
+        &:focus {
+            outline: 0;
+        }
+    }
+}

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -29,6 +29,14 @@ body {
     border: 2px solid $border-color !important;
     border-radius: 10px !important;
     min-height: 48px !important;
+
+    &.toast-bug {
+      border-color: red !important;
+
+      a {
+        color: red;
+      }
+    }
   }
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -30,12 +30,10 @@ try {
         { LiveSplit },
         React,
         { createRoot },
-        { ToastContainer },
     ] = await Promise.all([
         import("./ui/LiveSplit"),
         import("react"),
         import("react-dom/client"),
-        import("react-toastify"),
     ]);
 
     try {
@@ -86,25 +84,17 @@ try {
         const container = document.getElementById("base");
         const root = createRoot(container!);
         root.render(
-            <div>
-                <LiveSplit
-                    splits={splits}
-                    layout={layout}
-                    comparison={comparison}
-                    timingMethod={timingMethod}
-                    hotkeys={hotkeys}
-                    splitsKey={splitsKey}
-                    layoutWidth={layoutWidth}
-                    layoutHeight={layoutHeight}
-                    generalSettings={generalSettings}
-                />
-                <ToastContainer
-                    position="bottom-right"
-                    toastClassName="toast-class"
-                    bodyClassName="toast-body"
-                    theme="dark"
-                />
-            </div>,
+            <LiveSplit
+                splits={splits}
+                layout={layout}
+                comparison={comparison}
+                timingMethod={timingMethod}
+                hotkeys={hotkeys}
+                splitsKey={splitsKey}
+                layoutWidth={layoutWidth}
+                layoutHeight={layoutHeight}
+                generalSettings={generalSettings}
+            />,
         );
     } catch (e: any) {
         if (e.name === "InvalidStateError") {

--- a/src/ui/Dialog.tsx
+++ b/src/ui/Dialog.tsx
@@ -1,0 +1,103 @@
+import * as React from "react";
+
+import "../css/Dialog.scss";
+
+export interface Options {
+    title: string | JSX.Element,
+    description: string | JSX.Element,
+    textInput?: boolean,
+    defaultText?: string,
+    buttons: string[],
+}
+
+export interface State {
+    options: Options,
+    input: string,
+}
+
+let dialogElement: HTMLDialogElement | null = null;
+let setState: ((options: Options) => void) | undefined;
+let resolveFn: ((_: [number, string]) => void) | undefined;
+
+export function showDialog(options: Options): Promise<[number, string]> {
+    if (dialogElement) {
+        dialogElement.showModal();
+        const closeWith = options.buttons.length - 1;
+        dialogElement.onclose = () => {
+            resolveFn?.([closeWith, ""]);
+        };
+    }
+    setState?.(options);
+    return new Promise((resolve) => resolveFn = resolve);
+}
+
+export default class DialogContainer extends React.Component<unknown, State> {
+    constructor(props: unknown) {
+        super(props);
+
+        this.state = {
+            options: {
+                title: "",
+                description: "",
+                buttons: [],
+            },
+            input: "",
+        };
+    }
+
+    public componentDidMount(): void {
+        setState = (options) => this.setState({
+            options,
+            input: options.defaultText ?? "",
+        });
+    }
+
+    public render() {
+        return <dialog
+            tabIndex={-1}
+            ref={(element) => dialogElement = element}
+            onKeyDown={(e) => {
+                if (e?.key === "ArrowLeft") {
+                    e.preventDefault();
+                    (document.activeElement?.previousElementSibling as any)?.focus();
+                } else if (e?.key === "ArrowRight") {
+                    e.preventDefault();
+                    (document.activeElement?.nextElementSibling as any)?.focus();
+                }
+            }}
+        >
+            <h1>{this.state.options.title}</h1>
+            <p>{this.state.options.description}</p>
+            {
+                this.state.options.textInput && <input
+                    type="text"
+                    value={this.state.input}
+                    autoFocus={true}
+                    onChange={(e) => this.setState({ input: e.target.value })}
+                    onKeyDown={(e) => {
+                        if (e?.key === "Enter") {
+                            e.preventDefault();
+                            dialogElement?.close();
+                            resolveFn?.([0, this.state.input]);
+                        }
+                    }}
+                />
+            }
+            <div className="buttons">
+                {
+                    this.state.options.buttons.map((button, i) => {
+                        return <button
+                            autoFocus={i === 0 && !this.state.options.textInput}
+                            onClick={() => {
+                                dialogElement?.close();
+                                resolveFn?.([i, this.state.input]);
+                            }}
+                        >
+                            {button}
+                        </button>;
+                    })
+                }
+            </div>
+        </dialog>;
+    }
+}

--- a/src/ui/LSOEventSink.ts
+++ b/src/ui/LSOEventSink.ts
@@ -1,5 +1,6 @@
 import { EventSink, EventSinkRef, ImageCacheRefMut, LayoutEditorRefMut, LayoutRefMut, LayoutStateRefMut, Run, RunRef, TimeSpan, TimeSpanRef, Timer, TimerPhase, TimingMethod } from "../livesplit-core";
 import { WebEventSink } from "../livesplit-core/livesplit_core";
+import { showDialog } from "./Dialog";
 
 export class LSOEventSink {
     private eventSink: EventSink;
@@ -49,10 +50,18 @@ export class LSOEventSink {
         this.splitsModifiedChanged();
     }
 
-    public reset(): void {
+    public async reset(): Promise<void> {
         let updateSplits = true;
         if (this.timer.currentAttemptHasNewBestTimes()) {
-            updateSplits = confirm("You have beaten some of your best times. Do you want to update them?");
+            const [result] = await showDialog({
+                title: "Save Best Times?",
+                description: "You have beaten some of your best times. Do you want to update them?",
+                buttons: ["Yes", "No", "Don't Reset"],
+            });
+            if (result === 2) {
+                return;
+            }
+            updateSplits = result === 0;
         }
 
         this.timer.reset(updateSplits);

--- a/src/util/FileUtil.ts
+++ b/src/util/FileUtil.ts
@@ -5,14 +5,14 @@ import { Option } from "./OptionUtil";
 // @ts-expect-error Unused variable due to above issue
 let fileInputElement = null; // eslint-disable-line
 
-function openFile(): Promise<File> {
-    return new Promise((resolve, reject) => {
+function openFile(): Promise<File | undefined> {
+    return new Promise((resolve) => {
         const input = document.createElement("input");
         input.setAttribute("type", "file");
         input.onchange = () => {
             const file: Option<File> = input.files?.[0];
             if (file === undefined) {
-                reject();
+                resolve(undefined);
                 return;
             }
             resolve(file);
@@ -31,12 +31,16 @@ export async function convertFileToArrayBuffer(file: File): Promise<[ArrayBuffer
                 resolve([contents, file]);
             }
         };
+        // FIXME: onerror
         reader.readAsArrayBuffer(file);
     });
 }
 
-export async function openFileAsArrayBuffer(): Promise<[ArrayBuffer, File]> {
+export async function openFileAsArrayBuffer(): Promise<[ArrayBuffer, File] | undefined> {
     const file = await openFile();
+    if (file === undefined) {
+        return undefined;
+    }
     return convertFileToArrayBuffer(file);
 }
 
@@ -53,8 +57,11 @@ export async function convertFileToString(file: File): Promise<[string, File]> {
     });
 }
 
-export async function openFileAsString(): Promise<[string, File]> {
+export async function openFileAsString(): Promise<[string, File] | undefined> {
     const file = await openFile();
+    if (file === undefined) {
+        return undefined;
+    }
     return convertFileToString(file);
 }
 

--- a/src/util/OptionUtil.tsx
+++ b/src/util/OptionUtil.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { toast } from "react-toastify";
 
 export type Option<T> = T | null | undefined;
@@ -14,8 +15,25 @@ interface Disposable {
 }
 
 export function panic(message: string): never {
-    toast.error(`Bug: ${message}`);
+    bug(message);
     throw new Error(message);
+}
+
+export function bug(message: string): void {
+    toast.error(
+        <>
+            <b>You encountered a bug:</b>
+            <p><i>{message}</i></p>
+            Please report this issue <a
+                href="https://github.com/LiveSplit/LiveSplitOne"
+                target="_blank"
+            >here</a>.
+        </>,
+        {
+            autoClose: false,
+            className: "toast-class toast-bug",
+        },
+    );
 }
 
 export function assertNever(x: never): never { return x; }


### PR DESCRIPTION
This introduces custom dialogs to LiveSplit One. Previously we've used the builtin browser dialogs that are very limited in what they can do.

Additionally this introduces a bunch of smaller changes:
- The splits editor is now more optimized and only searches for the game name whenever it or the list of games changes.
- The PWA badge now resets when the app is reloaded.
- Guests on the leaderboard can now have flags.
- If a user encounters a bug, there's now dedicated toast popups that don't disappear and direct the user to the issue tracker.
- The Sum of Best cleaner now ensures the run can't be modified while the cleaning is in progress, which would lead to memory corruption, especially with the async nature of the new dialogs.
- Cancelling out of opening files doesn't lead to an error anymore.

The following changes are introduced by updating `livesplit-core`:
- When resizing images / reencoding them as PNG, we now use a higher compression setting.
- Invalid timer states are not representable anymore.