### PR TITLE
Clean up some async race conditions & CSS fixes

### DIFF
--- a/src/css/Dialog.scss
+++ b/src/css/Dialog.scss
@@ -1,52 +1,65 @@
 @import 'variables';
 
+.is-mobile+dialog>.dialog {
+    min-width: auto;
+}
+
 dialog {
-    color: #eee;
-    background: $main-background-color;
-    border: 2px solid $border-color;
-    border-radius: 10px;
-    min-width: 225px;
-    max-width: 400px;
-    padding: $ui-large-margin;
-
-    h1 {
-        font-size: 20px;
-        margin: 5px 0;
-    }
-
-    .buttons {
-        button {
-            font-size: 16px;
-            margin: 0;
-            min-width: 80px;
-
-            &:focus {
-                border-color: #888;
-            }
-        }
-
-        display: flex;
-        flex-direction: row;
-        justify-content: flex-end;
-        column-gap: $ui-margin;
-    }
+    background: none;
+    border: none;
+    outline: 0;
 
     &::backdrop {
         background: rgba(0, 0, 0, 0.5);
     }
 
-    input {
-        width: 100%;
-        border: none;
-        border-bottom: 1px solid hsla(0, 0%, 100%, 0.25);
-        background: transparent;
-        color: white;
-        text-overflow: ellipsis;
-        font-family: "fira", sans-serif;
-        font-size: 16px;
+    .dialog {
+        color: #eee;
+        background: $main-background-color;
+        border: 2px solid $border-color;
+        border-radius: 10px;
+        min-width: 225px;
 
-        &:focus {
-            outline: 0;
+        max-width: 400px;
+        padding: $ui-large-margin;
+
+        h1 {
+            font-size: 20px;
+            margin: 5px 0;
+        }
+
+        .buttons {
+            button {
+                font-size: 16px;
+                margin: 0;
+                min-width: 80px;
+                height: auto;
+
+                &:focus {
+                    border-color: #888;
+                }
+            }
+
+            display: flex;
+            flex-direction: row;
+            flex-wrap: wrap;
+            justify-content: flex-end;
+            gap: $ui-margin;
+        }
+
+        input {
+            width: 100%;
+            border: none;
+            border-bottom: 1px solid hsla(0, 0%, 100%, 0.25);
+            background: transparent;
+            color: white;
+            text-overflow: ellipsis;
+            font-family: "fira", sans-serif;
+            font-size: 16px;
+
+            &:focus {
+                outline: 0;
+            }
         }
     }
 }

--- a/src/css/HotkeyButton.scss
+++ b/src/css/HotkeyButton.scss
@@ -2,9 +2,11 @@
 
 .hotkey-box {
   button {
-    margin: 0px;
+    margin: 0;
     font-size: 16px;
-    height: 22px;
+    min-height: 22px;
+    padding-top: 0;
+    padding-bottom: 0;
   }
 
   .hotkey-button.focused {

--- a/src/css/LiveSplitServerButton.scss
+++ b/src/css/LiveSplitServerButton.scss
@@ -1,6 +1,10 @@
+@import 'variables';
+
 .livesplit-server-button {
-    margin: 0px;
+    margin: 0;
     font-size: 16px;
-    height: 22px;
+    min-height: 22px;
+    padding-top: 0;
+    padding-bottom: 0;
     // TODO: This is the same as the hotkey button.
 }

--- a/src/css/RunEditor.scss
+++ b/src/css/RunEditor.scss
@@ -270,7 +270,7 @@ $small-button-padding: 1px 3px 1px 3px;
       font-size: 15px;
       width: $button-width;
       margin-right: 0;
-      height: 30px;
+      min-height: 30px;
 
       @include mobile {
         margin-top: 0;
@@ -389,7 +389,7 @@ $small-button-padding: 1px 3px 1px 3px;
       content: "";
       height: 2px;
       width: 0;
-      bottom: 0px;
+      bottom: 0;
       position: absolute;
       background: hsla(50, 100%, 50%, 1);
       transition: 0.2s ease all;

--- a/src/css/Sidebar.scss
+++ b/src/css/Sidebar.scss
@@ -18,9 +18,13 @@ $h2-font-size: 22px;
 
   @include toggle;
 
-  >div>div.small>button {
-    width: 50%;
-    font-size: 18px;
+  >div>div.small {
+    display: flex;
+
+    >button {
+      width: 50%;
+      font-size: 18px;
+    }
   }
 
   .sidebar-buttons {

--- a/src/css/Table.scss
+++ b/src/css/Table.scss
@@ -12,12 +12,12 @@
 
     .table-row-even {
       display: table-row;
-      background: $dark-row-color  !important;
+      background: $dark-row-color !important;
     }
 
     .table-row-odd {
       display: table-row;
-      background: $light-row-color  !important;
+      background: $light-row-color !important;
     }
   }
 
@@ -54,16 +54,16 @@
   }
 
   .selected {
-    background: $selected-row-color  !important;
+    background: $selected-row-color !important;
   }
 
   .tab-bar>button {
     font-size: 15px;
-    height: 30px;
-    border-bottom-right-radius: 0px;
-    border-bottom-left-radius: 0px;
-    margin-bottom: 0px;
-    border-bottom: 0px;
+    min-height: 30px;
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0;
+    margin-bottom: 0;
+    border-bottom: 0;
   }
 
   tr>td>input {
@@ -144,9 +144,11 @@
           grid-template-columns: 1fr 30px;
 
           button {
-            margin: 0px;
+            margin: 0;
             font-size: 12px;
-            height: $settings-row-height;
+            min-height: $settings-row-height;
+            padding-top: 0;
+            padding-bottom: 0;
           }
         }
       }

--- a/src/css/Toggle.scss
+++ b/src/css/Toggle.scss
@@ -2,17 +2,17 @@
 
 @mixin toggle {
   .toggle-left {
-    border-top-right-radius: 0px;
-    border-bottom-right-radius: 0px;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
   }
 
   .toggle-right {
-    border-top-left-radius: 0px;
-    border-bottom-left-radius: 0px;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
   }
 
   .toggle-middle {
-    border-radius: 0px;
+    border-radius: 0;
   }
 
   .button-pressed,

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -59,7 +59,7 @@ td#dif {
 }
 
 table {
-  border-spacing: 0px 2px;
+  border-spacing: 0 2px;
 }
 
 button:active,
@@ -83,6 +83,7 @@ button {
   color: $button-text-color;
   cursor: pointer;
   font-size: 20px;
+  line-height: 1.1;
   border-width: 1px;
   border-style: solid;
   border-color: $border-color;
@@ -90,7 +91,8 @@ button {
   border-radius: 5px;
   font-weight: bold;
   font-family: "fira", sans-serif;
-  height: $button-height;
+  min-height: $button-height;
+  padding: 5px $ui-margin;
 }
 
 a {
@@ -124,7 +126,7 @@ button:disabled:active {
 ::-webkit-scrollbar-thumb {
   background-clip: padding-box;
   background-color: #303030;
-  border: 0px solid #0000;
+  border: 0 solid #0000;
   border-radius: 10px;
 }
 

--- a/src/ui/Dialog.tsx
+++ b/src/ui/Dialog.tsx
@@ -2,6 +2,11 @@ import * as React from "react";
 
 import "../css/Dialog.scss";
 
+export interface Props {
+    onShow: () => void,
+    onClose: () => void,
+}
+
 export interface Options {
     title: string | JSX.Element,
     description: string | JSX.Element,
@@ -18,22 +23,31 @@ export interface State {
 let dialogElement: HTMLDialogElement | null = null;
 let setState: ((options: Options) => void) | undefined;
 let resolveFn: ((_: [number, string]) => void) | undefined;
+let onCloseFn: (() => void) | undefined;
+let alreadyClosed = false;
 
 export function showDialog(options: Options): Promise<[number, string]> {
     if (dialogElement) {
         dialogElement.showModal();
+        alreadyClosed = false;
+        dialogElement.setAttribute("disabled", "");
         const closeWith = options.buttons.length - 1;
         dialogElement.onclose = () => {
-            resolveFn?.([closeWith, ""]);
+            if (!alreadyClosed) {
+                resolveFn?.([closeWith, ""]);
+                onCloseFn?.();
+            }
         };
     }
     setState?.(options);
     return new Promise((resolve) => resolveFn = resolve);
 }
 
-export default class DialogContainer extends React.Component<unknown, State> {
-    constructor(props: unknown) {
+export default class DialogContainer extends React.Component<Props, State> {
+    constructor(props: Props) {
         super(props);
+
+        onCloseFn = props.onClose;
 
         this.state = {
             options: {
@@ -46,15 +60,17 @@ export default class DialogContainer extends React.Component<unknown, State> {
     }
 
     public componentDidMount(): void {
-        setState = (options) => this.setState({
-            options,
-            input: options.defaultText ?? "",
-        });
+        setState = (options) => {
+            this.props.onShow();
+            this.setState({
+                options,
+                input: options.defaultText ?? "",
+            });
+        };
     }
 
     public render() {
         return <dialog
-            tabIndex={-1}
             ref={(element) => dialogElement = element}
             onKeyDown={(e) => {
                 if (e?.key === "ArrowLeft") {
@@ -66,38 +82,43 @@ export default class DialogContainer extends React.Component<unknown, State> {
                 }
             }}
         >
-            <h1>{this.state.options.title}</h1>
-            <p>{this.state.options.description}</p>
-            {
-                this.state.options.textInput && <input
-                    type="text"
-                    value={this.state.input}
-                    autoFocus={true}
-                    onChange={(e) => this.setState({ input: e.target.value })}
-                    onKeyDown={(e) => {
-                        if (e?.key === "Enter") {
-                            e.preventDefault();
-                            dialogElement?.close();
-                            resolveFn?.([0, this.state.input]);
-                        }
-                    }}
-                />
-            }
-            <div className="buttons">
+            <div className="dialog">
+                <h1>{this.state.options.title}</h1>
+                <p>{this.state.options.description}</p>
                 {
-                    this.state.options.buttons.map((button, i) => {
-                        return <button
-                            autoFocus={i === 0 && !this.state.options.textInput}
-                            onClick={() => {
-                                dialogElement?.close();
-                                resolveFn?.([i, this.state.input]);
-                            }}
-                        >
-                            {button}
-                        </button>;
-                    })
+                    this.state.options.textInput && <input
+                        type="text"
+                        value={this.state.input}
+                        autoFocus={true}
+                        onChange={(e) => this.setState({ input: e.target.value })}
+                        onKeyDown={(e) => {
+                            if (e?.key === "Enter") {
+                                e.preventDefault();
+                                this.close(0);
+                            }
+                        }}
+                    />
                 }
+                <div className="buttons">
+                    {
+                        this.state.options.buttons.map((button, i) => {
+                            return <button
+                                autoFocus={i === 0 && !this.state.options.textInput}
+                                onClick={() => this.close(i)}
+                            >
+                                {button}
+                            </button>;
+                        })
+                    }
+                </div>
             </div>
         </dialog>;
+    }
+
+    private close(i: number) {
+        alreadyClosed = true;
+        dialogElement?.close();
+        resolveFn?.([i, this.state.input]);
+        this.props.onClose();
     }
 }

--- a/src/ui/Settings.tsx
+++ b/src/ui/Settings.tsx
@@ -5,10 +5,11 @@ import ColorPicker from "./ColorPicker";
 import HotkeyButton from "./HotkeyButton";
 import ToggleCheckbox from "./ToggleCheckbox";
 import { UrlCache } from "../util/UrlCache";
-import { openFileAsArrayBuffer } from "../util/FileUtil";
+import { FILE_EXT_IMAGES, openFileAsArrayBuffer } from "../util/FileUtil";
 import * as FontList from "../util/FontList";
 import { LiveSplitServer } from "../api/LiveSplitServer";
 import { showDialog } from "./Dialog";
+import { toast } from "react-toastify";
 
 import "../css/Tooltip.scss";
 import "../css/LiveSplitServerButton.scss";
@@ -1251,8 +1252,12 @@ export class SettingsComponent<T> extends React.Component<Props<T>> {
                                     background: imageUrl ? `url("${imageUrl}") center / cover` : undefined,
                                 }}
                                 onClick={async (_) => {
-                                    const maybeFile = await openFileAsArrayBuffer();
+                                    const maybeFile = await openFileAsArrayBuffer(FILE_EXT_IMAGES);
                                     if (maybeFile === undefined) {
+                                        return;
+                                    }
+                                    if (maybeFile instanceof Error) {
+                                        toast.error(`Failed to read the file: ${maybeFile.message}`);
                                         return;
                                     }
                                     const [file] = maybeFile;

--- a/src/util/FileUtil.ts
+++ b/src/util/FileUtil.ts
@@ -5,10 +5,15 @@ import { Option } from "./OptionUtil";
 // @ts-expect-error Unused variable due to above issue
 let fileInputElement = null; // eslint-disable-line
 
-function openFile(): Promise<File | undefined> {
+export const FILE_EXT_SPLITS = ".lss";
+export const FILE_EXT_LAYOUTS = ".ls1l,.lsl";
+export const FILE_EXT_IMAGES = "image/*";
+
+function openFile(accept: string): Promise<File | undefined> {
     return new Promise((resolve) => {
         const input = document.createElement("input");
         input.setAttribute("type", "file");
+        input.setAttribute("accept", accept);
         input.onchange = () => {
             const file: Option<File> = input.files?.[0];
             if (file === undefined) {
@@ -22,43 +27,68 @@ function openFile(): Promise<File | undefined> {
     });
 }
 
-export async function convertFileToArrayBuffer(file: File): Promise<[ArrayBuffer, File]> {
-    return new Promise((resolve: (_: [ArrayBuffer, File]) => void) => {
-        const reader = new FileReader();
-        reader.onload = () => {
-            const contents = reader.result as Option<ArrayBuffer>;
-            if (contents != null) {
-                resolve([contents, file]);
+export async function convertFileToArrayBuffer(file: File): Promise<[ArrayBuffer, File] | Error> {
+    return new Promise((resolve: (_: [ArrayBuffer, File] | Error) => void) => {
+        try {
+            const reader = new FileReader();
+            reader.onload = () => {
+                const contents = reader.result as Option<ArrayBuffer>;
+                if (contents != null) {
+                    resolve([contents, file]);
+                } else {
+                    resolve(new Error("Failed to read the file."));
+                }
+            };
+            reader.onerror = () => {
+                resolve(new Error("Failed to read the file."));
+            };
+            reader.readAsArrayBuffer(file);
+        } catch (e) {
+            if (e instanceof Error) {
+                resolve(e);
+            } else {
+                resolve(new Error("Unknown error while reading the file."));
             }
-        };
-        // FIXME: onerror
-        reader.readAsArrayBuffer(file);
+        }
     });
 }
 
-export async function openFileAsArrayBuffer(): Promise<[ArrayBuffer, File] | undefined> {
-    const file = await openFile();
+export async function openFileAsArrayBuffer(accept: string): Promise<[ArrayBuffer, File] | Error | undefined> {
+    const file = await openFile(accept);
     if (file === undefined) {
         return undefined;
     }
     return convertFileToArrayBuffer(file);
 }
 
-export async function convertFileToString(file: File): Promise<[string, File]> {
-    return new Promise((resolve: (_: [string, File]) => void) => {
-        const reader = new FileReader();
-        reader.onload = () => {
-            const contents = reader.result as Option<string>;
-            if (contents != null) {
-                resolve([contents, file]);
+export async function convertFileToString(file: File): Promise<[string, File] | Error> {
+    return new Promise((resolve: (_: [string, File] | Error) => void) => {
+        try {
+            const reader = new FileReader();
+            reader.onload = () => {
+                const contents = reader.result as Option<string>;
+                if (contents != null) {
+                    resolve([contents, file]);
+                } else {
+                    resolve(new Error("Failed to read the file."));
+                }
+            };
+            reader.onerror = () => {
+                resolve(new Error("Failed to read the file."));
+            };
+            reader.readAsText(file);
+        } catch (e) {
+            if (e instanceof Error) {
+                resolve(e);
+            } else {
+                resolve(new Error("Unknown error while reading the file."));
             }
-        };
-        reader.readAsText(file);
+        }
     });
 }
 
-export async function openFileAsString(): Promise<[string, File] | undefined> {
-    const file = await openFile();
+export async function openFileAsString(accept: string): Promise<[string, File] | Error | undefined> {
+    const file = await openFile(accept);
     if (file === undefined) {
         return undefined;
     }

--- a/src/util/SplitsIO.ts
+++ b/src/util/SplitsIO.ts
@@ -74,13 +74,14 @@ export enum DownloadError {
     FailedParsing,
 }
 
-export async function downloadById(id: string): Promise<Run> {
+export async function downloadById(id: string, signal?: AbortSignal): Promise<Run> {
     const response = await validatedFetch(
         `https://splits.io/api/v4/runs/${id}`,
         {
             headers: new Headers({
                 Accept: "application/original-timer",
             }),
+            signal,
         },
         DownloadError.ApiRequestErrored,
     );


### PR DESCRIPTION
The dialogs are now asynchronous as opposed to the browser built-in ones that are synchronous, probably because they are incredibly old. The problem with the new dialogs being asynchronous is that for example the hotkeys, the server protocol and honestly any sort of async download that's still running in the background can all mess with the timer while the dialog is open. This could lead to all sorts of weird issues, like the timer being in a different state than what the dialog expects, the timer being reset twice and creating two dialogs that are open at the same time and possibly even memory corruption in the Rust code.

This commit ensures that the timer can not be interacted with while it is "locked for interaction". In fact we already had such a notion where when you navigate to the settings, layout or run editor, the hotkeys would be disabled. Now this is concept is extended so the event sink also can prevent interaction with the timer. Navigating to these menus and opening dialogs will now trigger this locking mechanism.

Additionally this improves various async race conditions in the splits editor related to downloading resources from speedrun.com or splits.io.

This also touches the CSS of the dialogs again, adding some spacing around the dialog, so it doesn't touch the edges of the window and allowing the buttons to have more dynamic sizing. In particular I've noticed that the text sometimes doesn't fit into the buttons on iOS, so they are now allowed to grow a little to handle that situation.

File open dialogs also now know the file extensions of the files we are looking for.