### PR TITLE
Add `Always On Top` setting for Tauri

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -62,6 +62,13 @@ fn resolve_hotkey(state: tauri::State<'_, State>, key_code: String) -> Cow<'stat
     key_code.into()
 }
 
+#[tauri::command]
+fn settings_changed(state: tauri::State<'_, State>, always_on_top: bool) {
+    if let Some(window) = &*state.window.read().unwrap() {
+        window.set_always_on_top(always_on_top).unwrap();
+    }
+}
+
 #[derive(Clone)]
 struct TauriCommandSink(Arc<RwLock<Option<Window>>>);
 
@@ -219,6 +226,7 @@ fn main() {
             set_hotkey_activation,
             get_hotkey_config,
             resolve_hotkey,
+            settings_changed,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/storage/index.tsx
+++ b/src/storage/index.tsx
@@ -257,6 +257,7 @@ export async function loadGeneralSettings(): Promise<GeneralSettings> {
         speedrunComIntegration: generalSettings.speedrunComIntegration ?? true,
         splitsIoIntegration: generalSettings.splitsIoIntegration ?? true,
         serverUrl: generalSettings.serverUrl,
+        alwaysOnTop: generalSettings.alwaysOnTop ?? (isTauri ? true : undefined),
     };
 }
 

--- a/src/ui/LiveSplit.tsx
+++ b/src/ui/LiveSplit.tsx
@@ -223,12 +223,12 @@ export class LiveSplit extends React.Component<Props, State> {
             layoutModified: false,
         };
 
-        if (window.__TAURI__ != null) {
-            window.__TAURI__.event.listen("command", (event) => {
-                const payloadString = JSON.stringify(event.payload);
-                ServerProtocol.handleCommand(payloadString, commandSink.getCommandSink().ptr);
-            });
-        }
+        window.__TAURI__?.event.listen("command", (event) => {
+            const payloadString = JSON.stringify(event.payload);
+            ServerProtocol.handleCommand(payloadString, commandSink.getCommandSink().ptr);
+        });
+
+        this.updateTauriSettings(props.generalSettings);
 
         this.updateBadge();
 
@@ -658,11 +658,18 @@ export class LiveSplit extends React.Component<Props, State> {
 
             this.state.hotkeySystem.setConfig(menu.config);
             this.setState({ generalSettings });
+            this.updateTauriSettings(generalSettings);
         } else {
             menu.config[Symbol.dispose]();
         }
 
         this.openTimerView();
+    }
+
+    private updateTauriSettings(generalSettings: GeneralSettings) {
+        window.__TAURI__?.tauri.invoke("settings_changed", {
+            alwaysOnTop: generalSettings.alwaysOnTop,
+        });
     }
 
     public onResize(width: number, height: number) {

--- a/src/ui/MainSettings.tsx
+++ b/src/ui/MainSettings.tsx
@@ -18,7 +18,8 @@ export interface GeneralSettings {
     saveOnReset: boolean,
     speedrunComIntegration: boolean,
     splitsIoIntegration: boolean,
-    serverUrl: string | undefined,
+    serverUrl?: string,
+    alwaysOnTop?: boolean,
 }
 
 export interface Props {
@@ -112,6 +113,11 @@ export class MainSettings extends React.Component<Props, State> {
                                     Bool: this.state.generalSettings.saveOnReset,
                                 },
                             },
+                            ...((window.__TAURI__ != null) ? [{
+                                text: "Always On Top",
+                                tooltip: "Keeps the window always on top of other windows.",
+                                value: { Bool: this.state.generalSettings.alwaysOnTop! },
+                            }] : []),
                         ],
                     }}
                     editorUrlCache={this.props.urlCache}
@@ -158,6 +164,16 @@ export class MainSettings extends React.Component<Props, State> {
                                         generalSettings: {
                                             ...this.state.generalSettings,
                                             saveOnReset: value.Bool,
+                                        },
+                                    });
+                                }
+                                break;
+                            case 4:
+                                if ("Bool" in value) {
+                                    this.setState({
+                                        generalSettings: {
+                                            ...this.state.generalSettings,
+                                            alwaysOnTop: value.Bool,
                                         },
                                     });
                                 }


### PR DESCRIPTION
This adds support for the `Always On Top` setting in the Tauri version of LiveSplit One. This setting allows you to keep the LiveSplit One window on top of all other windows.