### PR TITLE
Fix Desktop Build on Linux

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -11,7 +11,11 @@ edition = "2021"
 tauri-build = { version = "1", features = [] }
 
 [dependencies]
-tauri = { version = "1", features = [ "http-all"] }
+tauri = { version = "1", features = [
+    "dialog-all",
+    "http-all",
+    "linux-protocol-headers",
+] }
 serde = { version = "1" }
 serde_derive = { version = "1" }
 serde_json = "1"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -11,10 +11,15 @@
   "tauri": {
     "allowlist": {
       "all": false,
+      "dialog": {
+        "all": true
+      },
       "http": {
         "all": true,
         "request": true,
-        "scope": ["https://www.speedrun.com/static/*"]
+        "scope": [
+          "https://www.speedrun.com/static/*"
+        ]
       }
     },
     "windows": [


### PR DESCRIPTION
WebAssembly needs a specific mime type to be allowed to be loaded. Tauri by default apparently can't send headers on Linux, unless you activate a specific feature, so the WebAssembly failed to load. Additionally, without the dialog feature, it also wasn't able to show the error message.