### PR TITLE
Add Setting for Manual Game Time Input Mode

### DIFF
--- a/src/storage/index.tsx
+++ b/src/storage/index.tsx
@@ -1,7 +1,7 @@
 import { openDB, IDBPDatabase } from "idb";
 import { Option, assert } from "../util/OptionUtil";
 import { RunRef, Run, TimingMethod } from "../livesplit-core";
-import { GeneralSettings } from "../ui/MainSettings";
+import { GeneralSettings, MANUAL_GAME_TIME_SETTINGS_DEFAULT } from "../ui/MainSettings";
 import { FRAME_RATE_AUTOMATIC } from "../util/FrameRate";
 
 export type HotkeyConfigSettings = unknown;
@@ -248,6 +248,10 @@ export async function loadGeneralSettings(): Promise<GeneralSettings> {
     const generalSettings = await db.get("settings", "generalSettings") ?? {};
 
     const isTauri = window.__TAURI__ != null;
+
+    if (generalSettings.showManualGameTime === true) {
+        generalSettings.showManualGameTime = MANUAL_GAME_TIME_SETTINGS_DEFAULT;
+    }
 
     return {
         frameRate: generalSettings.frameRate ?? FRAME_RATE_AUTOMATIC,

--- a/src/ui/LSOCommandSink.ts
+++ b/src/ui/LSOCommandSink.ts
@@ -1,4 +1,4 @@
-import { CommandError, CommandResult, CommandSink, CommandSinkRef, Event, ImageCacheRefMut, LayoutEditorRefMut, LayoutRefMut, LayoutStateRefMut, Run, RunRef, TimeSpan, TimeSpanRef, Timer, TimerPhase, TimingMethod, isEvent } from "../livesplit-core";
+import { CommandError, CommandResult, CommandSink, CommandSinkRef, Event, ImageCacheRefMut, LayoutEditorRefMut, LayoutRefMut, LayoutStateRefMut, Run, RunRef, TimeRef, TimeSpan, TimeSpanRef, Timer, TimerPhase, TimingMethod, isEvent } from "../livesplit-core";
 import { WebCommandSink } from "../livesplit-core/livesplit_core";
 import { assert } from "../util/OptionUtil";
 import { showDialog } from "./Dialog";
@@ -408,6 +408,10 @@ export class LSOCommandSink {
         imageCache: ImageCacheRefMut,
     ): void {
         layoutEditor.updateLayoutState(layoutState, imageCache, this.timer);
+    }
+
+    public currentTime(): TimeRef {
+        return this.timer.currentTime();
     }
 
     public currentSplitIndex(): number {

--- a/src/ui/TimerView.tsx
+++ b/src/ui/TimerView.tsx
@@ -6,7 +6,7 @@ import DragUpload from "./DragUpload";
 import Layout from "../layout/Layout";
 import { UrlCache } from "../util/UrlCache";
 import { WebRenderer } from "../livesplit-core/livesplit_core";
-import { GeneralSettings } from "./MainSettings";
+import { GeneralSettings, MANUAL_GAME_TIME_MODE_SEGMENT_TIMES } from "./MainSettings";
 import { LiveSplitServer } from "../api/LiveSplitServer";
 import { LSOCommandSink } from "./LSOCommandSink";
 
@@ -73,6 +73,8 @@ export class TimerView extends React.Component<Props, State> {
     }
 
     private renderView() {
+        const showManualGameTime = this.props.generalSettings.showManualGameTime;
+
         return <DragUpload
             importLayout={(file) => this.props.callbacks.importLayoutFromFile(file)}
             importSplits={(file) => this.props.callbacks.importSplitsFromFile(file)}
@@ -167,7 +169,7 @@ export class TimerView extends React.Component<Props, State> {
                 </div>
             }
             {
-                this.props.generalSettings.showManualGameTime && <div className="buttons" style={{ width: this.props.layoutWidth }}>
+                showManualGameTime && <div className="buttons" style={{ width: this.props.layoutWidth }}>
                     <input
                         type="text"
                         className="manual-game-time"
@@ -191,6 +193,12 @@ export class TimerView extends React.Component<Props, State> {
                                 } else {
                                     using gameTime = TimeSpan.parse(this.state.manualGameTime);
                                     if (gameTime !== null) {
+                                        if (showManualGameTime.mode === MANUAL_GAME_TIME_MODE_SEGMENT_TIMES) {
+                                            const currentGameTime = timer.currentTime().gameTime();
+                                            if (currentGameTime !== null) {
+                                                gameTime.addAssign(currentGameTime);
+                                            }
+                                        }
                                         timer.setGameTimeInner(gameTime);
                                         timer.split();
                                         this.setState({ manualGameTime: "" });


### PR DESCRIPTION
This allows the user to choose between specifying segment times and split times when using the manual game timer.

Changelog: When using the **Manual Game Time Input**, you can now choose between specifying **Segment Times** and **Split Times**.