### PR TITLE
Don't Use WasmGC Instructions Just Yet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,19 @@ jobs:
         shell: bash
         run: |
           WASM_FILE=$(ls ${{ matrix.dist_path }}/*.wasm)
-          wasm-opt --all-features -O4 "$WASM_FILE" -o "$WASM_FILE"
+          wasm-opt \
+            --enable-bulk-memory \
+            --enable-mutable-globals \
+            --enable-nontrapping-float-to-int \
+            --enable-sign-ext \
+            --enable-simd \
+            --enable-extended-const \
+            --enable-multivalue \
+            --enable-reference-types \
+            --strip-dwarf \
+            --strip-producers \
+            --strip-target-features \
+            -O4 "$WASM_FILE" -o "$WASM_FILE"
 
       - name: Build (Tauri)
         if: matrix.platform == 'tauri'

--- a/buildCore.js
+++ b/buildCore.js
@@ -4,8 +4,9 @@ import fs from "fs";
 let toolchain = "";
 let profile = "debug";
 let cargoFlags = "";
+// Keep .github/workflows/ci.yml in sync with these flags, so wasm-opt works.
 let rustFlags =
-    "-C target-feature=+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext,+simd128,+extended-const,+multivalue";
+    "-C target-feature=+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext,+simd128,+extended-const,+multivalue,+reference-types";
 let wasmBindgenFlags = "--encode-into always --target web --reference-types";
 let target = "wasm32-unknown-unknown";
 let targetFolder = target;

--- a/wasm32-multivalue.json
+++ b/wasm32-multivalue.json
@@ -10,7 +10,6 @@
     "exe-suffix": ".wasm",
     "generate-arange-section": false,
     "has-thread-local": true,
-    "is-builtin": false,
     "is-like-wasm": true,
     "limit-rdylib-exports": false,
     "linker": "rust-lld",


### PR DESCRIPTION
At some point we had to switch away from `wasm-opt` automatically detecting the WebAssembly features, because they deprecated and turned that into a no-op. Since then we specified that it should just use all the features. This used to work all the time, but with the introduction of reference types it now started optimizing some of those instructions into instructions that are only available with the `WasmGC` proposal. This slipped through because Chrome and Firefox already support `WasmGC` but Safari does not... yet, because they also will start to support it very soon. In the meantime and also to ensure `wasm-opt` isn't ever going to sneak in any unwanted features, we now explicitly specify all the features that we want to use.