### PR TITLE
Disable Multivalue again

### DIFF
--- a/buildCore.js
+++ b/buildCore.js
@@ -39,8 +39,10 @@ if (process.argv.some((v) => v === "--nightly")) {
     cargoFlags +=
         " -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort";
     rustFlags += " -Z wasm-c-abi=spec";
-    target = "../wasm32-multivalue.json";
-    targetFolder = "wasm32-multivalue";
+
+    // FIXME: Apparently the multivalue ABI is broken again.
+    // target = "../wasm32-multivalue.json";
+    // targetFolder = "wasm32-multivalue";
 
     // Virtual function elimination requires LTO, so we can only do it for
     // max-opt builds.

--- a/wasm32-multivalue.json
+++ b/wasm32-multivalue.json
@@ -1,7 +1,7 @@
 {
     "arch": "wasm32",
     "crt-objects-fallback": "true",
-    "data-layout": "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20",
+    "data-layout": "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-i128:128-n32:64-S128-ni:1:10:20",
     "dll-prefix": "",
     "dll-suffix": ".wasm",
     "dynamic-linking": true,


### PR DESCRIPTION
Apparently it's currently broken again in the recent Rust nightlies, so we have to disable it.