### PR TITLE
Fix Bugs Introduced in Refactoring

### DIFF
--- a/src/platform/Hotkeys.ts
+++ b/src/platform/Hotkeys.ts
@@ -2,7 +2,7 @@ import { CommandSinkRef, HotkeyConfig, HotkeySystem } from "../livesplit-core";
 import { expect } from "../util/OptionUtil";
 
 export interface HotkeyImplementation {
-    ptr: number;
+    ptr?: number;
     config(): Promise<HotkeyConfig> | HotkeyConfig;
     setConfig(config: HotkeyConfig): void;
     activate(): void;
@@ -11,10 +11,7 @@ export interface HotkeyImplementation {
 }
 
 class GlobalHotkeys implements HotkeyImplementation {
-    public ptr: number;
-    constructor(private hotkeySystem?: HotkeySystem) {
-        this.ptr = hotkeySystem?.ptr ?? 0;
-    }
+    constructor(private hotkeySystem?: HotkeySystem) { }
 
     public async config(): Promise<HotkeyConfig> {
         return expect(

--- a/src/ui/LiveSplit.tsx
+++ b/src/ui/LiveSplit.tsx
@@ -1170,7 +1170,9 @@ async function popOut(
     element.style.width = "100%";
     element.style.height = "100%";
 
-    if (hotkeySystem) HotkeySystem_add_window(hotkeySystem.ptr, childWindow);
+    if (hotkeySystem?.ptr) {
+        HotkeySystem_add_window(hotkeySystem.ptr, childWindow);
+    }
 
     createRoot(childDoc.body).render(
         <ShowLayout


### PR DESCRIPTION
The splits selection view did not correctly cause rerenders among other smaller bugs in there. I'm not sure how these bugs got introduced, as I barely made changes to the content of the functions, but these were completely different. Maybe this was Copilot's fault.

Additionally, when using Tauri, there was a bug where we had two hotkey implementations at the same time for the pop out windows. One was the global hotkey implementation and one was the local one we add to the pop out window. This caused the hotkey to be triggered twice.