### PR TITLE
Fix Sidebar Not Refreshing in Splits Selection

### DIFF
--- a/src/ui/views/SplitsSelection.tsx
+++ b/src/ui/views/SplitsSelection.tsx
@@ -99,13 +99,7 @@ export function SplitsSelection(props: Props) {
     };
 
     return props.callbacks.renderViewWithSidebar(
-        <View
-            commandSink={props.commandSink}
-            openedSplitsKey={props.openedSplitsKey}
-            callbacks={props.callbacks}
-            splitsInfos={splitsInfos}
-            refreshDb={refreshDb}
-        />,
+        <View {...props} splitsInfos={splitsInfos} refreshDb={refreshDb} />,
         <SideBar
             commandSink={props.commandSink}
             callbacks={props.callbacks}


### PR DESCRIPTION
When the splits selection view is open, the sidebar and the view itself don't refresh properly anymore when in mobile mode. This is because the React compiler notices that with the way we wrote the code, these components have no reason to re-render. There is currently no proper `useMobile` hook. So while I implemented a quick workaround here, by forcing it to not memoize the individual props properly, we should refactor the sidebar code at some point to use a proper `useMobile` hook.