### PR TITLE
Ensure HTTPS is used for Speedrun.com Pagination

### DIFF
--- a/buildCore.js
+++ b/buildCore.js
@@ -6,7 +6,7 @@ let profile = "debug";
 let cargoFlags = "";
 // Keep .github/workflows/ci.yml in sync with these flags, so wasm-opt works.
 let rustFlags =
-  "-C target-feature=+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext,+simd128,+extended-const,+multivalue,+reference-types,+tail-call";
+    "-C target-feature=+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext,+simd128,+extended-const,+multivalue,+reference-types,+tail-call";
 let wasmBindgenFlags = "--encode-into always --target web --reference-types";
 let target = "wasm32-unknown-unknown";
 let targetFolder = target;
@@ -36,9 +36,9 @@ if (process.argv.some((v) => v === "--unstable")) {
 // Use the nightly toolchain, which enables some more optimizations.
 if (process.argv.some((v) => v === "--nightly")) {
     toolchain = "+nightly";
-    cargoFlags +=
-        " -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort";
-    rustFlags += " -Z wasm-c-abi=spec";
+    cargoFlags += " -Z build-std=std,panic_abort";
+    rustFlags +=
+        " -Z wasm-c-abi=spec -Z unstable-options -C panic=immediate-abort";
 
     // FIXME: Apparently the multivalue ABI is broken again.
     // Caused by: https://github.com/rust-lang/rust/pull/135534
@@ -71,20 +71,20 @@ execSync(
             ...process.env,
             RUSTFLAGS: rustFlags,
         },
-    }
+    },
 );
 
 execSync(
     `wasm-bindgen ${wasmBindgenFlags} livesplit-core/target/${targetFolder}/${profile}/livesplit_core.wasm --out-dir src/livesplit-core`,
     {
         stdio: "inherit",
-    }
+    },
 );
 
 fs.createReadStream(
-    "livesplit-core/capi/bindings/wasm_bindgen/web/index.ts"
+    "livesplit-core/capi/bindings/wasm_bindgen/web/index.ts",
 ).pipe(fs.createWriteStream("src/livesplit-core/index.ts"));
 
 fs.createReadStream(
-    "livesplit-core/capi/bindings/wasm_bindgen/web/preload.ts"
+    "livesplit-core/capi/bindings/wasm_bindgen/web/preload.ts",
 ).pipe(fs.createWriteStream("src/livesplit-core/preload.ts"));

--- a/src/api/SpeedrunCom.ts
+++ b/src/api/SpeedrunCom.ts
@@ -316,8 +316,9 @@ async function executePaginatedRequest<T>(uri: string): Promise<Page<T>> {
     if (pagination.links != null) {
         const nextLink = pagination.links.find((l: any) => l.rel === "next");
         if (nextLink != null) {
-            const link = nextLink.uri as string;
-            next = () => executePaginatedRequest<T>(link);
+            const link = new URL(nextLink.uri as string);
+            link.protocol = "https:"; // Ensure HTTPS, their API seems to return HTTP links.
+            next = () => executePaginatedRequest<T>(link.toString());
         }
     }
     return new Page(data as T[], next);


### PR DESCRIPTION
Apparently their API returns HTTP links for pagination, which seems to get blocked nowadays. This forces the use of HTTPS for those links.