### PR TITLE
Fixed reset not considering the message's argument

### DIFF
--- a/src/ui/views/TimerView.tsx
+++ b/src/ui/views/TimerView.tsx
@@ -180,7 +180,7 @@ function View({
                         <button
                             aria-label="Reset"
                             disabled={currentPhase === TimerPhase.NotRunning}
-                            onClick={(_) => commandSink.reset()}
+                            onClick={(_) => commandSink.reset(undefined)}
                         >
                             <X strokeWidth={3.5} />
                         </button>

--- a/src/util/LSOCommandSink.ts
+++ b/src/util/LSOCommandSink.ts
@@ -111,7 +111,7 @@ export class LSOCommandSink {
         return result;
     }
 
-    public async reset(updateSplits: boolean | undefined): Promise<CommandResult> {
+    public async reset(updateSplits?: boolean): Promise<CommandResult> {
         if (this.locked) {
             return CommandError.Busy;
         }
@@ -129,7 +129,7 @@ export class LSOCommandSink {
             updateSplits = result === 0;
         }
 
-        const result = this.timer.reset(updateSplits) as CommandResult;
+        const result = this.timer.reset(updateSplits ?? true) as CommandResult;
 
         if (isEvent(result)) {
             this.callbacks.handleEvent(result);


### PR DESCRIPTION
Before this pull request, LiveSplitOne would not consider the server's "saveAttempt" argument when receiving a reset command. This makes sure the command is full taken into account, by asking the user if they wish to save the times if and only if the command has not provided the "saveAttempt" argument.