### PR TITLE
Load the Polyfills First

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,26 +1,8 @@
+// The polyfill must be imported before anything else, as it may be required by
+// other modules.
+import "./polyfill";
 import { preloadWasm } from "./livesplit-core/preload";
 import { Label, resolve } from "./localization";
-
-// FIXME: Remove the polyfill later.
-// https://caniuse.com/mdn-javascript_statements_using
-
-if (typeof Symbol.dispose !== "symbol") {
-    Object.defineProperty(Symbol, "dispose", {
-        configurable: false,
-        enumerable: false,
-        writable: false,
-        value: Symbol.for("dispose"),
-    });
-}
-
-if (typeof Symbol.asyncDispose !== "symbol") {
-    Object.defineProperty(Symbol, "asyncDispose", {
-        configurable: false,
-        enumerable: false,
-        writable: false,
-        value: Symbol.for("asyncDispose"),
-    });
-}
 
 if (
     process.env.NODE_ENV === "production" &&

--- a/src/polyfill.ts
+++ b/src/polyfill.ts
@@ -1,0 +1,19 @@
+// FIXME: Remove the polyfill later.
+// https://caniuse.com/mdn-javascript_statements_using
+if (typeof Symbol.dispose !== "symbol") {
+    Object.defineProperty(Symbol, "dispose", {
+        configurable: false,
+        enumerable: false,
+        writable: false,
+        value: Symbol.for("dispose"),
+    });
+}
+
+if (typeof Symbol.asyncDispose !== "symbol") {
+    Object.defineProperty(Symbol, "asyncDispose", {
+        configurable: false,
+        enumerable: false,
+        writable: false,
+        value: Symbol.for("asyncDispose"),
+    });
+}


### PR DESCRIPTION
The polyfills need to be loaded first to ensure that they are available for the rest of the code. This is especially important for the `Symbol.dispose` polyfill, as any classes using it might not properly declare their methods when it's still `undefined`.