### PR TITLE
Autosave active splits while timing

### DIFF
--- a/src/ui/LiveSplit.tsx
+++ b/src/ui/LiveSplit.tsx
@@ -204,6 +204,9 @@ export class LiveSplit extends React.Component<Props, State> {
     private scrollEvent: Option<EventListenerObject>;
     private rightClickEvent: Option<EventListenerObject>;
     private resizeEvent: Option<EventListenerObject>;
+    private autoSaveInterval: Option<ReturnType<typeof setInterval>> = null;
+    private autoSaveInProgress = false;
+    private autoSaveAfterCurrent = false;
 
     constructor(props: Props) {
         super(props);
@@ -353,6 +356,7 @@ export class LiveSplit extends React.Component<Props, State> {
         this.isDesktopQuery.addEventListener("change", this.mediaQueryChanged);
 
         this.handleAutomaticResize();
+        this.updateAutoSaveInterval();
 
         const { serviceWorker } = navigator;
         if (serviceWorker && serviceWorker.controller) {
@@ -368,6 +372,7 @@ export class LiveSplit extends React.Component<Props, State> {
     }
 
     public componentWillUnmount() {
+        this.stopAutoSaveInterval();
         window.removeEventListener(
             "wheel",
             expect(
@@ -1068,6 +1073,66 @@ export class LiveSplit extends React.Component<Props, State> {
         }
     }
 
+    private shouldAutoSaveSplits(): boolean {
+        const phase = this.state.commandSink.currentPhase();
+        return (
+            phase === TimerPhase.Running ||
+            phase === TimerPhase.Paused ||
+            phase === TimerPhase.Ended
+        );
+    }
+
+    private updateAutoSaveInterval(): void {
+        if (!this.shouldAutoSaveSplits()) {
+            this.stopAutoSaveInterval();
+            return;
+        }
+
+        if (this.autoSaveInterval !== null) {
+            return;
+        }
+
+        // The serialized timer snapshot contains the in-progress attempt, so
+        // periodically saving the splits keeps browser restarts from wiping the
+        // current run's progress.
+        this.autoSaveInterval = setInterval(() => {
+            void this.autoSaveSplits();
+        }, 3000);
+    }
+
+    private stopAutoSaveInterval(): void {
+        if (this.autoSaveInterval === null) {
+            return;
+        }
+
+        clearInterval(this.autoSaveInterval);
+        this.autoSaveInterval = null;
+    }
+
+    private async autoSaveSplits(): Promise<void> {
+        if (!this.shouldAutoSaveSplits()) {
+            this.stopAutoSaveInterval();
+            return;
+        }
+
+        if (this.autoSaveInProgress) {
+            this.autoSaveAfterCurrent = true;
+            return;
+        }
+
+        this.autoSaveInProgress = true;
+        try {
+            await this.saveSplits();
+        } finally {
+            this.autoSaveInProgress = false;
+        }
+
+        if (this.autoSaveAfterCurrent) {
+            this.autoSaveAfterCurrent = false;
+            void this.autoSaveSplits();
+        }
+    }
+
     onServerConnectionOpened(serverConnection: LiveSplitServer): void {
         this.setState({ serverConnection });
     }
@@ -1134,6 +1199,11 @@ export class LiveSplit extends React.Component<Props, State> {
 
         if (this.state.serverConnection != null) {
             this.state.serverConnection.sendEvent(event);
+        }
+
+        this.updateAutoSaveInterval();
+        if (this.shouldAutoSaveSplits()) {
+            void this.autoSaveSplits();
         }
     }
 


### PR DESCRIPTION
## Summary
- periodically autosave the current splits while the timer is running, paused, or finished but not reset
- reuse the existing IndexedDB splits storage and `Timer.saveAsLssBytes()` path so a browser restart reloads the latest autosaved splits
- avoid overlapping autosave writes and stop the interval once the timer is no longer in an active phase

Fixes #971.

## Validation
- `npm ci`
- `git diff --check`
- `npx eslint src/ui/LiveSplit.tsx --no-ignore` currently fails on the pre-existing generated-binding type issue at `src/ui/LiveSplit.tsx:311` (`Language` resolves as an error type because generated `src/livesplit-core` bindings are not present)
- `npm run publish` is blocked for the same missing generated `src/livesplit-core` imports
- `npm run build:core` cannot be run on this host because `cargo` is not installed